### PR TITLE
Spec for Reunion SDK's drag & drop API

### DIFF
--- a/specs/dragdrop-api/dragdrop-api.md
+++ b/specs/dragdrop-api/dragdrop-api.md
@@ -56,7 +56,7 @@ This does a lot of initialization and basically informs the system that your app
 var manager = DragDropManager.GetForCurrentWindow();
 ```
 
-1. Implement `IDropOperationTarget`:
+2. Implement `IDropOperationTarget`:
 
 ```c#
 class DropTarget : IDropOperationTarget
@@ -115,7 +115,7 @@ DataPackageOperation result = await dragOperation.StartAsync();
 
 # Remarks
 
-Coming soon.
+None at this time.
 
 # API Notes
 
@@ -123,21 +123,22 @@ Coming soon.
   * `GetForCurrentWindow`: Static method that constructs a `DragDropManager` which allows you to set the window as a drop target.
   * `TargetRequested`: Construct a `DropOperationTargetRequestedEventArgs` to provide a `IDropOperationTarget` implementation for your window.
   * ...
-* `DragInfo`
+* `DragInfo`: Provides information to the target app about the type of data being dragged, and what operations are allowed (Copy/Move/Link).
   * ...
 * `DragOperation`: Object used to create and start a drag operation from your app.
   * `AllowedOperations`: Use this property to set the complete set of operations the source app wishes to allow in drag and drop scenarios. You can specify zero or more flags. To set a desired default operation, use the `DataPackage.RequestedOperation` property. Users can override this choices by using SHIFT and CTRL keys. In this case, the target app must inspect the key state to determine the operation the user selected.
   * ...
 * `DragUIContentMode`: Use this to specify whether the `DragOperation` should wait for content load before starting, or run in parallel.
-* `DragUIOverride`
+* `DragUIOverride`: Provides various settings to customize the drag UI by a target app.
   * ...
 * `DropOperationTargetRequestedEventArgs`
   * `SetTarget`: Provide your implementation of `IDropOperationTarget` which specifies the actions your app should take when the user is hovering over your application's window.
-* `IDropOperationTarget`
-  * `DropAsync`
-  * `EnterAsync`
-  * `LeaveAsync`
-  * `OverAsync`
+* `IDropOperationTarget`: All four of the functions on this interface provide `DragInfo` as a parameter. This allows the target app to check the data of the drag operation and inform the system if it can accept the drag or not.
+  * `DropAsync`: Called if and only if when the user releases the pointer, the last returned value of the previous `EnterAsync` or `OverAsync` matches a `DataPackageOperation` specified by the source app in `CoreDragInfo.AllowedOperations`.
+  * `EnterAsync`: Called initially when a mouse cursor enters an app's window for the first time. Note that this is also called when a drag is initially started - in this case, the target is just the same app. This is effectively a special case of `OverAsync` (below).
+  * `LeaveAsync`: : Called if the current target has not communicated that it can accept a drop.
+  * `OverAsync`: Called constantly in what effectively is a busy loop. The target can do things like check the current coordinates of the drag location via `DragInfo.Position` and update the UI via `DragUIOverride`, depending on the data being dragged and the visual element under the cursor.
+  * **IMPORTANT:** For a successful drop to occur, the return value of `EnterAsync` and `OverAsync` should match a `DataPackageOperation` specified in `DragInfo.AllowedOperations` which is set by the source app. It is the responsibility of the target app implementing `IDropOperationTarget` to verify it can accept the drop and communicate this back to the system via the return values of these functions.
 
 # API Details
 
@@ -147,4 +148,4 @@ of the Project Reunion SDK's drag & drop API.
 
 # Appendix
 
-Coming soon.
+* `GetForCurrentWindow` identifies the type of window (user32 HWND/CoreWindow/AppWindow) being used by the caller and does the necessary setup to make sure input events are correctly delivered.

--- a/specs/dragdrop-api/dragdrop-api.md
+++ b/specs/dragdrop-api/dragdrop-api.md
@@ -1,0 +1,153 @@
+# Background
+
+## Current Windows drag & drop API surface
+
+Drag & drop is a feature that allows the user to "drag" data - text, images, files, hyperlinks, etc. from one point on the screen to another. This could be within the same or between different applications.
+
+Today, Windows platform provides two primary APIs to enable this functionality:
+
+* [The OLE drag & drop API](https://docs.microsoft.com/en-us/windows/win32/api/ole2/nf-ole2-dodragdrop) ("OLE drag & drop) usually called by all classic Win32 apps.
+* [The UWP drag & drop API](https://docs.microsoft.com/en-us/uwp/api/windows.applicationmodel.datatransfer.dragdrop.core?view=winrt-19041) ("UWP drag & drop") callable (today) by CoreWindow-based UWP apps.
+
+A common way developers implement drag & drop functionality in their apps is via the UI framework which provides wrappers for the platform drag & drop APIs in the UI elements. For example, XAML/WinUI or WPF:
+
+* XAML/WinUI - Wrapper around UWP drag & drop. [Blog post](https://docs.microsoft.com/en-us/archive/msdn-magazine/2015/august/windows-10-modern-drag-and-drop-for-windows-universal-applications). [Samples](https://github.com/microsoft/Windows-universal-samples/tree/master/Samples/XamlDragAndDrop).
+* WPF - Wrapper around OLE drag & drop. [Documentation](https://docs.microsoft.com/en-us/dotnet/framework/wpf/advanced/drag-and-drop-overview).
+
+NOTE: It is important to note that use of a UI framework is _not_ necessary to implement drag & drop functionality in an app. An app can implement drag & drop by directly calling one of the two OLE or UWP APIs.
+
+## Motivation for Project Reunion drag & drop
+
+1. **Bring modern drag & drop to all classic apps in an easy-to-incorporate package:** Foremost among the issues we want to address is that the existing drag & drop APIs can be cumbersome to use; especially the older OLE API, and its wrappers such as WPF. In addition, the OLE API is lacking in modern, illustrative UI. With this Project Reunion API, we plan to bring the ability to access modern drag & drop for _all_ apps.
+
+2. **Evolve the API to make it easier-to-use in general, and incorporate feedback from the community:** Drag & drop as a feature is something that is intuitive for users, and satisfying to use. Especially in a touch-first world, we belive there is a lot of value in empowering developers to make this feature easy-to-implement to build apps that delight customers. Additionally, this will allow us to iterate on improvements/fixes a lot faster than shipping with the Windows SDK.
+
+# Description
+
+ Drag & drop is an intuitive feature that make for delightful app experiences for end users. When you use Windows' UI frameworks such as XAML/WinUI, you get their built-in support for drag & drop with minimal overhead. However, if you are not using those, implementing drag & drop can be challenging. This Project Reunion SDK API aims to alleviate that challenge by providing a feature-rich drag & drop experience in an easy-to-use set of APIs.
+
+The Reunion SDK drag & drop API is very similar to Windows' built-in "UWP drag & drop" API in the `Windows.ApplicationModel.DataTransfer.DragDrop.Core` Windows Runtime namespace. In fact, in this initial version (as of mid-2020), the Reunion SDK drag & drop API is almost the same as `Windows.ApplicationModel.DataTransfer.DragDrop.Core`, except for these differences:
+
+1. The namespace is now `Microsoft.Reunion.DragDrop`.
+2. The addition of `GetForHWND()` API to register any Windows app as a drop target.
+
+# Examples
+
+## Enabling your application's window to be a drop target
+
+Let's say you are building the next greatest photo organizer app. To add photos to the library, you want to enable users to drag in files, for example from File Explorer to your app. To do this, you need to set your application's HWND/CoreWindow/AppWindow to be a drop target.
+
+1. Get `CoreDragDropManager`:
+
+This does a lot of initialization and basically informs the system that your app wants to register for drag & drop. Note that `CoreDragDropManager` is *per window*.
+
+1a. If you have **classic HWND-based** application:
+
+```c#
+// C#
+HWND hwnd; // HWND you got from CreateWindow or CreateWindowEx
+var manager = CoreDragDropManager.GetForWindow(hwnd);
+```
+```c++
+// C++/WinRT
+
+HWND hwnd; // HWND you got from CreateWindow or CreateWindowEx
+CoreDragDropManager manager{ CoreDragDropManager::GetForWindow(hwnd) };
+```
+
+1b. If you have a **CoreWindow/AppWindow-based** application:
+
+```c#
+// C#
+
+var manager = CoreDragDropManager.GetForCurrentView();
+```
+```c++
+// C++/WinRT
+
+CoreDragDropManager manager{ CoreDragDropManager::GetForCurrentView() };
+```
+
+2. Implement `ICoreDropOperationTarget`:
+
+```c#
+// C#
+
+class DropTarget : ICoreDropOperationTarget
+{
+    public IAsyncOperation<DataPackageOperation> EnterAsync(CoreDragInfo dragInfo, CoreDragUIOverride dragUIOverride)
+    {
+        throw new NotImplementedException();
+    }
+
+    public IAsyncOperation<DataPackageOperation> OverAsync(CoreDragInfo dragInfo, CoreDragUIOverride dragUIOverride)
+    {
+        throw new NotImplementedException();
+    }
+
+    public IAsyncAction LeaveAsync(CoreDragInfo dragInfo)
+    {
+        throw new NotImplementedException();
+    }
+
+    public IAsyncOperation<DataPackageOperation> DropAsync(CoreDragInfo dragInfo)
+    {
+        throw new NotImplementedException();
+    }
+}
+```
+
+3. Provide your new drop target to the `CoreDragDropManager`:
+
+```c#
+// C#
+
+var onDropTargetRequestedHandler = new TypedEventHandler<CoreDragDropManager, CoreDropOperationTargetRequestedEventArgs>(
+    delegate (CoreDragDropManager handlerManager, CoreDropOperationTargetRequestedEventArgs handlerArgs)
+    {
+        handlerArgs.SetTarget(new DropTarget());
+    }
+);
+manager.TargetRequested += onDropTargetRequestedHandler;
+```
+
+## Enabling your application to be a drag source (start drag & drop operations)
+
+### *** TODO ***
+
+# Remarks
+
+Coming soon.
+
+# API Notes
+
+* `CoreDragDropManager`: Initializes drag & drop environment to enable an application window to be set as a drop target.
+  * `GetForCurrentView`: Static method that constructs a `CoreDragDropManager` for a CoreWindow/AppWindow app.
+  * `GetForHWND`: Static method that constructs a `CoreDragDropManager` for a classic HWND-based windowing app.
+  * `TargetRequested`: Construct a `CoreDropOperationTargetRequestedEventArgs` to provide a `ICoreDropOperationTarget` implementation for your window.
+  * ...
+* `CoreDragInfo`
+  * ...
+* `CoreDragOperation`: Object used to create and start a drag operation from your app.
+  * `AllowedOperations`: Use this property to set the complete set of operations the source app wishes to allow in drag and drop scenarios. You can specify zero or more flags. To set a desired default operation, use the `DataPackage.RequestedOperation` property. Users can override this choices by using SHIFT and CTRL keys. In this case, the target app must inspect the key state to determine the operation the user selected.
+  * ...
+* `CoreDragUIContentMode`: Use this to specify whether the `CoreDragOperation` should wait for content load before starting, or run in parallel.
+* `CoreDragUIOverride`
+  * ...
+* `CoreDropOperationTargetRequestedEventArgs`
+  * `SetTarget`: Provide your implementation of `ICoreDropOperationTarget` which specifies the actions your app should take when the user is hovering over your application's window.
+* `ICoreDropOperationTarget`
+  * `DropAsync`
+  * `EnterAsync`
+  * `LeaveAsync`
+  * `OverAsync`
+
+# API Details
+
+See [`dragdrop.idl`](dragdrop.idl) for a complete [MIDL 3.0](
+https://docs.microsoft.com/uwp/midl-3/) description
+of the Project Reunion SDK's drag & drop API.
+
+# Appendix
+
+Coming soon.

--- a/specs/dragdrop-api/dragdrop-api.md
+++ b/specs/dragdrop-api/dragdrop-api.md
@@ -39,8 +39,9 @@ TODO: how much functionality exists for routing touch drag & drop on Desktop
 
 The Reunion SDK drag & drop API is very similar to Windows' built-in "UWP drag & drop" API in the `Windows.ApplicationModel.DataTransfer.DragDrop.` Windows Runtime namespace. In fact, in this initial version (as of mid-2020), the Reunion SDK drag & drop API is almost the same as `Windows.ApplicationModel.DataTransfer.DragDrop.`, except for these differences:
 
-1. The namespace is now `Microsoft.ProjectReunion.ApplicationModel.DragDrop`.
+1. The namespace is now `Microsoft.ProjectReunion.ApplicationModel`.
 2. `DragDropManager::GetForCurrentView()` has been renamed to `GetForCurrentWindow()` and has changes in its implementation to allow its construction from a UWP appmodel application that uses Window/AppWindow, as well as from a classic Win32 app that uses `USER32.dll` windows aka HWNDs.
+3. `DragDropManager::AreConcurrentOperationsEnabled` in v1 of this API as this is a special scenario currently only used by CShell and does not need to be exposed.
 
 # Examples
 

--- a/specs/dragdrop-api/dragdrop-api.md
+++ b/specs/dragdrop-api/dragdrop-api.md
@@ -90,7 +90,7 @@ class DropTarget : IDropOperationTarget
 var onDropTargetRequestedHandler = new TypedEventHandler<DragDropManager, DropOperationTargetRequestedEventArgs>(
     delegate (DragDropManager handlerManager, DropOperationTargetRequestedEventArgs handlerArgs)
     {
-        handlerArgs.DropTarget = new DropTarget();
+        handlerArgs.SetTarget(new DropTarget());
     }
 );
 manager.TargetRequested += onDropTargetRequestedHandler;

--- a/specs/dragdrop-api/dragdrop-api.md
+++ b/specs/dragdrop-api/dragdrop-api.md
@@ -4,17 +4,17 @@
 
 Drag & drop is a feature that allows the user to "drag" data - text, images, files, hyperlinks, etc. from one point on the screen to another. This could be within the same or between different applications.
 
-Today, Windows platform provides two primary APIs to enable this functionality:
+Today, the Windows platform provides two primary APIs to enable this functionality:
 
 * [The OLE drag & drop API](https://docs.microsoft.com/en-us/windows/win32/api/ole2/nf-ole2-dodragdrop) ("OLE drag & drop) usually called by all classic Win32 apps.
-* [The UWP drag & drop API](https://docs.microsoft.com/en-us/uwp/api/windows.applicationmodel.datatransfer.dragdrop.core?view=winrt-19041) ("UWP drag & drop") callable (today) by CoreWindow-based UWP apps.
+* [The UWP drag & drop API](https://docs.microsoft.com/en-us/uwp/api/windows.applicationmodel.datatransfer.dragdrop.core?view=winrt-19041) ("UWP drag & drop") callable (today) by Window-based UWP apps.
 
-A common way developers implement drag & drop functionality in their apps is via the UI framework which provides wrappers for the platform drag & drop APIs in the UI elements. For example, XAML/WinUI or WPF:
+A common way developers implement drag & drop functionality in their apps is via their app's UI framework which provides wrappers for the platform drag & drop APIs. For example, XAML/WinUI or WPF:
 
 * XAML/WinUI - Wrapper around UWP drag & drop. [Blog post](https://docs.microsoft.com/en-us/archive/msdn-magazine/2015/august/windows-10-modern-drag-and-drop-for-windows-universal-applications). [Samples](https://github.com/microsoft/Windows-universal-samples/tree/master/Samples/XamlDragAndDrop).
 * WPF - Wrapper around OLE drag & drop. [Documentation](https://docs.microsoft.com/en-us/dotnet/framework/wpf/advanced/drag-and-drop-overview).
 
-NOTE: It is important to note that use of a UI framework is _not_ necessary to implement drag & drop functionality in an app. An app can implement drag & drop by directly calling one of the two OLE or UWP APIs.
+NOTE: It is important to note that use of a UI framework is _not_ necessary to implement drag & drop functionality in an app. An app can implement drag & drop by directly calling either the OLE or UWP platform API.
 
 ## Motivation for Project Reunion drag & drop
 
@@ -22,88 +22,70 @@ NOTE: It is important to note that use of a UI framework is _not_ necessary to i
 
 2. **Evolve the API to make it easier-to-use in general, and incorporate feedback from the community:** Drag & drop as a feature is something that is intuitive for users, and satisfying to use. Especially in a touch-first world, we belive there is a lot of value in empowering developers to make this feature easy-to-implement to build apps that delight customers. Additionally, this will allow us to iterate on improvements/fixes a lot faster than shipping with the Windows SDK.
 
+<!-- break out into two points 
+
+Problems in gap between UWP and Win32.
+
+1. Customer promise that touch drag & drop works (preferably) out of the box.
+TODO: how much functionality exists for routing touch drag & drop on Desktop
+
+-->
+
 # Description
 
  Drag & drop is an intuitive feature that make for delightful app experiences for end users. When you use Windows' UI frameworks such as XAML/WinUI, you get their built-in support for drag & drop with minimal overhead. However, if you are not using those, implementing drag & drop can be challenging. This Project Reunion SDK API aims to alleviate that challenge by providing a feature-rich drag & drop experience in an easy-to-use set of APIs.
 
-The Reunion SDK drag & drop API is very similar to Windows' built-in "UWP drag & drop" API in the `Windows.ApplicationModel.DataTransfer.DragDrop.Core` Windows Runtime namespace. In fact, in this initial version (as of mid-2020), the Reunion SDK drag & drop API is almost the same as `Windows.ApplicationModel.DataTransfer.DragDrop.Core`, except for these differences:
+The Reunion SDK drag & drop API is very similar to Windows' built-in "UWP drag & drop" API in the `Windows.ApplicationModel.DataTransfer.DragDrop.` Windows Runtime namespace. In fact, in this initial version (as of mid-2020), the Reunion SDK drag & drop API is almost the same as `Windows.ApplicationModel.DataTransfer.DragDrop.`, except for these differences:
 
-1. The namespace is now `Microsoft.Reunion.DragDrop`.
-2. The addition of `GetForHWND()` API to register any Windows app as a drop target.
+1. The namespace is now `Microsoft.ProjectReunion.ApplicationModel.DragDrop`.
+2. `DragDropManager::GetForCurrentView()` has been renamed to `GetForCurrentWindow()` and has changes in its implementation to allow its construction from a UWP appmodel application that uses Window/AppWindow, as well as from a classic Win32 app that uses `USER32.dll` windows aka HWNDs.
 
 # Examples
 
 ## Enabling your application's window to be a drop target
 
-Let's say you are building the next greatest photo organizer app. To add photos to the library, you want to enable users to drag in files, for example from File Explorer to your app. To do this, you need to set your application's HWND/CoreWindow/AppWindow to be a drop target.
+Let's say you are building the next greatest photo organizer app. To add photos to the library, you want to enable users to drag in files, for example from File Explorer to your app. To do this, you need to set your application's HWND/Window/AppWindow to be a drop target.
 
-1. Get `CoreDragDropManager`:
+1. Construct `DragDropManager`:
 
-This does a lot of initialization and basically informs the system that your app wants to register for drag & drop. Note that `CoreDragDropManager` is *per window*.
-
-1a. If you have **classic HWND-based** application:
+This does a lot of initialization and basically informs the system that your app wants to register for drag & drop. Note that `DragDropManager` is *per window*.
 
 ```c#
-// C#
-HWND hwnd; // HWND you got from CreateWindow or CreateWindowEx
-var manager = CoreDragDropManager.GetForWindow(hwnd);
-```
-```c++
-// C++/WinRT
-
-HWND hwnd; // HWND you got from CreateWindow or CreateWindowEx
-CoreDragDropManager manager{ CoreDragDropManager::GetForWindow(hwnd) };
+var manager = DragDropManager.GetForCurrentView();
 ```
 
-1b. If you have a **CoreWindow/AppWindow-based** application:
+1. Implement `IDropOperationTarget`:
 
 ```c#
-// C#
-
-var manager = CoreDragDropManager.GetForCurrentView();
-```
-```c++
-// C++/WinRT
-
-CoreDragDropManager manager{ CoreDragDropManager::GetForCurrentView() };
-```
-
-2. Implement `ICoreDropOperationTarget`:
-
-```c#
-// C#
-
-class DropTarget : ICoreDropOperationTarget
+class DropTarget : IDropOperationTarget
 {
-    public IAsyncOperation<DataPackageOperation> EnterAsync(CoreDragInfo dragInfo, CoreDragUIOverride dragUIOverride)
+    public IAsyncOperation<DataPackageOperation> EnterAsync(DragInfo dragInfo, DragUIOverride dragUIOverride)
     {
-        throw new NotImplementedException();
+        // your code here
     }
 
-    public IAsyncOperation<DataPackageOperation> OverAsync(CoreDragInfo dragInfo, CoreDragUIOverride dragUIOverride)
+    public IAsyncOperation<DataPackageOperation> OverAsync(DragInfo dragInfo, DragUIOverride dragUIOverride)
     {
-        throw new NotImplementedException();
+        // your code here
     }
 
-    public IAsyncAction LeaveAsync(CoreDragInfo dragInfo)
+    public IAsyncAction LeaveAsync(DragInfo dragInfo)
     {
-        throw new NotImplementedException();
+        // your code here
     }
 
-    public IAsyncOperation<DataPackageOperation> DropAsync(CoreDragInfo dragInfo)
+    public IAsyncOperation<DataPackageOperation> DropAsync(DragInfo dragInfo)
     {
-        throw new NotImplementedException();
+        // your code here
     }
 }
 ```
 
-3. Provide your new drop target to the `CoreDragDropManager`:
+3. Provide your new drop target to the `DragDropManager`:
 
 ```c#
-// C#
-
-var onDropTargetRequestedHandler = new TypedEventHandler<CoreDragDropManager, CoreDropOperationTargetRequestedEventArgs>(
-    delegate (CoreDragDropManager handlerManager, CoreDropOperationTargetRequestedEventArgs handlerArgs)
+var onDropTargetRequestedHandler = new TypedEventHandler<DragDropManager, DropOperationTargetRequestedEventArgs>(
+    delegate (DragDropManager handlerManager, DropOperationTargetRequestedEventArgs handlerArgs)
     {
         handlerArgs.SetTarget(new DropTarget());
     }
@@ -114,16 +96,14 @@ manager.TargetRequested += onDropTargetRequestedHandler;
 ## Enabling your application to be a drag source (start drag & drop operations)
 
 ```c#
-// C#
+DragOperation dragOperation = new DragOperation();
 
-CoreDragOperation dragOperation = new CoreDragOperation();
-
-// Set your data on the DataPackage on the CoreDragOperation
-DataPackage dataPackage = dragOperation.Data;
-dataPackage.SetText("Hello from another app!");
+// Set your data on the DataPackage provided in the DragOperation
+DataPackage dragOperationDataPackage = dragOperation.Data;
+dragOperationDataPackage.SetText("Hello from another app!");
 
 // Set default operation
-dataPackage.RequestedOperation = DataPackageOperation.Copy;
+dragOperationDataPackage.RequestedOperation = DataPackageOperation.Copy;
 
 // Set allowed operations
 dragOperation.AllowedOperations = DataPackageOperation.Copy | DataPackageOperation.Move;
@@ -137,22 +117,22 @@ Coming soon.
 
 # API Notes
 
-* `CoreDragDropManager`: Initializes drag & drop environment to enable an application window to be set as a drop target.
-  * `GetForCurrentView`: Static method that constructs a `CoreDragDropManager` for a CoreWindow/AppWindow app.
-  * `GetForHWND`: Static method that constructs a `CoreDragDropManager` for a classic HWND-based windowing app.
-  * `TargetRequested`: Construct a `CoreDropOperationTargetRequestedEventArgs` to provide a `ICoreDropOperationTarget` implementation for your window.
+* `DragDropManager`: Initializes drag & drop environment to enable an application window to be set as a drop target.
+  * `GetForCurrentView`: Static method that constructs a `DragDropManager` for a Window/AppWindow app.
+  * `GetForHWND`: Static method that constructs a `DragDropManager` for a classic HWND-based windowing app.
+  * `TargetRequested`: Construct a `DropOperationTargetRequestedEventArgs` to provide a `IDropOperationTarget` implementation for your window.
   * ...
-* `CoreDragInfo`
+* `DragInfo`
   * ...
-* `CoreDragOperation`: Object used to create and start a drag operation from your app.
+* `DragOperation`: Object used to create and start a drag operation from your app.
   * `AllowedOperations`: Use this property to set the complete set of operations the source app wishes to allow in drag and drop scenarios. You can specify zero or more flags. To set a desired default operation, use the `DataPackage.RequestedOperation` property. Users can override this choices by using SHIFT and CTRL keys. In this case, the target app must inspect the key state to determine the operation the user selected.
   * ...
-* `CoreDragUIContentMode`: Use this to specify whether the `CoreDragOperation` should wait for content load before starting, or run in parallel.
-* `CoreDragUIOverride`
+* `DragUIContentMode`: Use this to specify whether the `DragOperation` should wait for content load before starting, or run in parallel.
+* `DragUIOverride`
   * ...
-* `CoreDropOperationTargetRequestedEventArgs`
-  * `SetTarget`: Provide your implementation of `ICoreDropOperationTarget` which specifies the actions your app should take when the user is hovering over your application's window.
-* `ICoreDropOperationTarget`
+* `DropOperationTargetRequestedEventArgs`
+  * `SetTarget`: Provide your implementation of `IDropOperationTarget` which specifies the actions your app should take when the user is hovering over your application's window.
+* `IDropOperationTarget`
   * `DropAsync`
   * `EnterAsync`
   * `LeaveAsync`

--- a/specs/dragdrop-api/dragdrop-api.md
+++ b/specs/dragdrop-api/dragdrop-api.md
@@ -18,9 +18,11 @@ NOTE: It is important to note that use of a UI framework is _not_ necessary to i
 
 ## Motivation for Project Reunion drag & drop
 
-1. **Bring modern drag & drop to all classic apps in an easy-to-incorporate package:** Foremost among the issues we want to address is that the existing drag & drop APIs can be cumbersome to use; especially the older OLE API, and its wrappers such as WPF. In addition, the OLE API is lacking in modern, illustrative UI. With this Project Reunion API, we plan to bring the ability to access modern drag & drop for _all_ apps.
+1. **Bring modern drag & drop to all classic apps in an easy-to-incorporate package:** Foremost among the issues we want to address is that the existing drag & drop APIs can be cumbersome to use; especially the older OLE API, and its wrappers such as WPF. In addition, the OLE API has limited support for drag UI customization - showing, hiding, or changing the glyph of the object being dragged; adding a caption, or other visual aids to help the user understand the effect of a drag operation, etc. Modern drag & drop provides these customizations. With this Project Reunion API, we plan to bring access to the modern drag & drop experience for _all_ apps.
 
-2. **Evolve the API to make it easier-to-use in general, and incorporate feedback from the community:** Drag & drop as a feature is something that is intuitive for users, and satisfying to use. Especially in a touch-first world, we belive there is a lot of value in empowering developers to make this feature easy-to-implement to build apps that delight customers. Additionally, this will allow us to iterate on improvements/fixes a lot faster than shipping with the Windows SDK.
+2. **Evolve the API to make it easier-to-use in general:** Drag & drop as a feature is something that is intuitive for users, and satisfying to use. Especially in a touch-first world, we believe there is a lot of value in empowering developers to make this feature easy-to-implement to build apps that delight customers. This Project Reunion API aims to do so by wrapping away even more of the decision-making, and so making it easier for developers.
+
+3. **Incorporate feedback from the developer community:** Additionally, this will allow us to iterate on improvements/fixes a lot faster than shipping with the Windows SDK as well as incorporate suggestions from our developer community.
 
 <!-- break out into two points 
 
@@ -51,7 +53,7 @@ Let's say you are building the next greatest photo organizer app. To add photos 
 This does a lot of initialization and basically informs the system that your app wants to register for drag & drop. Note that `DragDropManager` is *per window*.
 
 ```c#
-var manager = DragDropManager.GetForCurrentView();
+var manager = DragDropManager.GetForCurrentWindow();
 ```
 
 1. Implement `IDropOperationTarget`:
@@ -87,7 +89,7 @@ class DropTarget : IDropOperationTarget
 var onDropTargetRequestedHandler = new TypedEventHandler<DragDropManager, DropOperationTargetRequestedEventArgs>(
     delegate (DragDropManager handlerManager, DropOperationTargetRequestedEventArgs handlerArgs)
     {
-        handlerArgs.SetTarget(new DropTarget());
+        handlerArgs.DropTarget = new DropTarget();
     }
 );
 manager.TargetRequested += onDropTargetRequestedHandler;
@@ -99,11 +101,11 @@ manager.TargetRequested += onDropTargetRequestedHandler;
 DragOperation dragOperation = new DragOperation();
 
 // Set your data on the DataPackage provided in the DragOperation
-DataPackage dragOperationDataPackage = dragOperation.Data;
-dragOperationDataPackage.SetText("Hello from another app!");
+DataPackage dataPackage = dragOperation.Data;
+dataPackage.SetText("Hello from another app!");
 
 // Set default operation
-dragOperationDataPackage.RequestedOperation = DataPackageOperation.Copy;
+dataPackage.RequestedOperation = DataPackageOperation.Copy;
 
 // Set allowed operations
 dragOperation.AllowedOperations = DataPackageOperation.Copy | DataPackageOperation.Move;
@@ -118,8 +120,7 @@ Coming soon.
 # API Notes
 
 * `DragDropManager`: Initializes drag & drop environment to enable an application window to be set as a drop target.
-  * `GetForCurrentView`: Static method that constructs a `DragDropManager` for a Window/AppWindow app.
-  * `GetForHWND`: Static method that constructs a `DragDropManager` for a classic HWND-based windowing app.
+  * `GetForCurrentWindow`: Static method that constructs a `DragDropManager` which allows you to set the window as a drop target.
   * `TargetRequested`: Construct a `DropOperationTargetRequestedEventArgs` to provide a `IDropOperationTarget` implementation for your window.
   * ...
 * `DragInfo`

--- a/specs/dragdrop-api/dragdrop-api.md
+++ b/specs/dragdrop-api/dragdrop-api.md
@@ -113,7 +113,23 @@ manager.TargetRequested += onDropTargetRequestedHandler;
 
 ## Enabling your application to be a drag source (start drag & drop operations)
 
-### *** TODO ***
+```c#
+// C#
+
+CoreDragOperation dragOperation = new CoreDragOperation();
+
+// Set your data on the DataPackage on the CoreDragOperation
+DataPackage dataPackage = dragOperation.Data;
+dataPackage.SetText("Hello from another app!");
+
+// Set default operation
+dataPackage.RequestedOperation = DataPackageOperation.Copy;
+
+// Set allowed operations
+dragOperation.AllowedOperations = DataPackageOperation.Copy | DataPackageOperation.Move;
+
+DataPackageOperation result = await dragOperation.StartAsync();
+```
 
 # Remarks
 

--- a/specs/dragdrop-api/dragdrop.idl
+++ b/specs/dragdrop-api/dragdrop.idl
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corp. Licensed under the MIT license.
 
-namespace Microsoft.Reunion.DragDrop
+namespace Microsoft.ProjectReunion.ApplicationModel.DragDrop
 {
     // Forward declare
-    runtimeclass CoreDragInfo;
-    runtimeclass CoreDragOperation;
-    runtimeclass CoreDragUIOverride;
-    runtimeclass CoreDragDropManager;
-    runtimeclass CoreDropOperationTargetRequestedEventArgs;
+    runtimeclass DragInfo;
+    runtimeclass DragOperation;
+    runtimeclass DragUIOverride;
+    runtimeclass DragDropManager;
+    runtimeclass DropOperationTargetRequestedEventArgs;
 
     enum DragDropModifiers
     {
@@ -20,60 +20,59 @@ namespace Microsoft.Reunion.DragDrop
         RightButton = 0x20
     };
 
-    enum CoreDragUIContentMode
+    enum DragUIContentMode
     {
         Auto,
         Deferred,
     };
 
-    runtimeclass CoreDragInfo
+    runtimeclass DragInfo
     {
         Microsoft.Reunion.ApplicationModel.DataPackage Data { get; };
-        Microsoft.Reunion.DragDrop.DragDropModifiers Modifiers { get; };
+        DragDropModifiers Modifiers { get; };
         Windows.Foundation.Point Position { get; };
         Microsoft.Reunion.ApplicationModel.DataPackage.DataPackageOperation AllowedOperations { get; };
     }
 
-    runtimeclass CoreDragUIOverride
+    runtimeclass DragUIOverride
     {
         void SetContentFromSoftwareBitmap(Windows.Graphics.Imaging.SoftwareBitmap softwareBitmap);
         void SetContentFromSoftwareBitmapWithAnchorPoint(Windows.Graphics.Imaging.SoftwareBitmap softwareBitmap, Windows.Foundation.Point anchorPoint);
-        boolean IsContentVisible;
+        Boolean IsContentVisible;
         String Caption;
-        boolean IsCaptionVisible;
-        boolean IsGlyphVisible;
+        Boolean IsCaptionVisible;
+        Boolean IsGlyphVisible;
         void Clear();
     }
 
-    interface ICoreDropOperationTarget
+    interface IDropOperationTarget
     {
-        Windows.Foundation.IAsyncOperation<Microsoft.Reunion.ApplicationModel.DataPackageOperation> EnterAsync(CoreDragInfo dragInfo, CoreDragUIOverride dragUIOverride);
-        Windows.Foundation.IAsyncOperation<Microsoft.Reunion.ApplicationModel.DataPackageOperation> OverAsync(CoreDragInfo dragInfo, CoreDragUIOverride dragUIOverride);
-        Windows.Foundation.IAsyncAction LeaveAsync(CoreDragInfo dragInfo);
-        Windows.Foundation.IAsyncOperation<Microsoft.Reunion.ApplicationModel.DataPackageOperation> DropAsync(CoreDragInfo dragInfo);
+        Windows.Foundation.IAsyncOperation<Microsoft.Reunion.ApplicationModel.DataPackageOperation> EnterAsync(DragInfo dragInfo, DragUIOverride dragUIOverride);
+        Windows.Foundation.IAsyncOperation<Microsoft.Reunion.ApplicationModel.DataPackageOperation> OverAsync(DragInfo dragInfo, DragUIOverride dragUIOverride);
+        Windows.Foundation.IAsyncAction LeaveAsync(DragInfo dragInfo);
+        Windows.Foundation.IAsyncOperation<Microsoft.Reunion.ApplicationModel.DataPackageOperation> DropAsync(DragInfo dragInfo);
     }
 
-    runtimeclass CoreDragOperation
+    runtimeclass DragOperation
     {
         Microsoft.Reunion.ApplicationModel.DataPackageOperation AllowedOperations;
         Microsoft.Reunion.ApplicationModel.DataPackage Data { get; };
-        CoreDragUIContentMode DragUIContentMode;
+        DragUIContentMode DragUIContentMode;
         void SetPointerId(UInt32 pointerId);
         void SetDragUIContentFromSoftwareBitmap(Windows.Graphics.Imaging.SoftwareBitmap softwareBitmap);
         void SetDragUIContentFromSoftwareBitmapWithAnchorPoint(Windows.Graphics.Imaging.SoftwareBitmap softwareBitmap, Windows.Foundation.Point anchorPoint);
         Windows.Foundation.IAsyncOperation<Microsoft.Reunion.ApplicationModel.DataPackageOperation> StartAsync();
     }
 
-    runtimeclass ICoreDragDropManager
+    runtimeclass DragDropManager
     {
-        CoreDragDropManager GetForCurrentView();
-        CoreDragDropManager GetForHWND(HWND hwnd);
-        event Windows.Foundation.TypedEventHandler<CoreDragDropManager, CoreDropOperationTargetRequestedEventArgs> TargetRequested;
-        boolean AreConcurrentOperationsEnabled;
+        DragDropManager GetForCurrentWindow();
+        event Windows.Foundation.TypedEventHandler<DragDropManager, DropOperationTargetRequestedEventArgs> TargetRequested;
+        Boolean AreConcurrentOperationsEnabled;
     }
 
-    runtimeclass CoreDropOperationTargetRequestedEventArgs
+    runtimeclass DropOperationTargetRequestedEventArgs
     {
-        void SetTarget(CoreDropOperationTarget target);
+        void SetTarget(DropOperationTarget target);
     }
-} // Microsoft.Reunion.DragDrop
+} // Microsoft.ProjectReunion.ApplicationModel.DragDrop

--- a/specs/dragdrop-api/dragdrop.idl
+++ b/specs/dragdrop-api/dragdrop.idl
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corp. Licensed under the MIT license.
+
+namespace Microsoft.Reunion.DragDrop
+{
+    // Forward declare
+    runtimeclass CoreDragInfo;
+    runtimeclass CoreDragOperation;
+    runtimeclass CoreDragUIOverride;
+    runtimeclass CoreDragDropManager;
+    runtimeclass CoreDropOperationTargetRequestedEventArgs;
+
+    enum DragDropModifiers
+    {
+        None = 0x0,
+        Shift = 0x1,
+        Control = 0x2,
+        Alt = 0x4,
+        LeftButton = 0x8,
+        MiddleButton = 0x10,
+        RightButton = 0x20
+    };
+
+    enum CoreDragUIContentMode
+    {
+        Auto,
+        Deferred,
+    };
+
+    runtimeclass CoreDragInfo
+    {
+        Microsoft.Reunion.ApplicationModel.DataPackage Data { get; };
+        Microsoft.Reunion.DragDrop.DragDropModifiers Modifiers { get; };
+        Windows.Foundation.Point Position { get; };
+        Microsoft.Reunion.ApplicationModel.DataPackage.DataPackageOperation AllowedOperations { get; };
+    }
+
+    runtimeclass CoreDragUIOverride
+    {
+        void SetContentFromSoftwareBitmap(Windows.Graphics.Imaging.SoftwareBitmap softwareBitmap);
+        void SetContentFromSoftwareBitmapWithAnchorPoint(Windows.Graphics.Imaging.SoftwareBitmap softwareBitmap, Windows.Foundation.Point anchorPoint);
+        boolean IsContentVisible;
+        String Caption;
+        boolean IsCaptionVisible;
+        boolean IsGlyphVisible;
+        void Clear();
+    }
+
+    interface ICoreDropOperationTarget
+    {
+        Windows.Foundation.IAsyncOperation<Microsoft.Reunion.ApplicationModel.DataPackageOperation> EnterAsync(CoreDragInfo dragInfo, CoreDragUIOverride dragUIOverride);
+        Windows.Foundation.IAsyncOperation<Microsoft.Reunion.ApplicationModel.DataPackageOperation> OverAsync(CoreDragInfo dragInfo, CoreDragUIOverride dragUIOverride);
+        Windows.Foundation.IAsyncAction LeaveAsync(CoreDragInfo dragInfo);
+        Windows.Foundation.IAsyncOperation<Microsoft.Reunion.ApplicationModel.DataPackageOperation> DropAsync(CoreDragInfo dragInfo);
+    }
+
+    runtimeclass CoreDragOperation
+    {
+        Microsoft.Reunion.ApplicationModel.DataPackageOperation AllowedOperations;
+        Microsoft.Reunion.ApplicationModel.DataPackage Data { get; };
+        CoreDragUIContentMode DragUIContentMode;
+        void SetPointerId(UInt32 pointerId);
+        void SetDragUIContentFromSoftwareBitmap(Windows.Graphics.Imaging.SoftwareBitmap softwareBitmap);
+        void SetDragUIContentFromSoftwareBitmapWithAnchorPoint(Windows.Graphics.Imaging.SoftwareBitmap softwareBitmap, Windows.Foundation.Point anchorPoint);
+        Windows.Foundation.IAsyncOperation<Microsoft.Reunion.ApplicationModel.DataPackageOperation> StartAsync();
+    }
+
+    runtimeclass ICoreDragDropManager
+    {
+        CoreDragDropManager GetForCurrentView();
+        CoreDragDropManager GetForHWND(HWND hwnd);
+        event Windows.Foundation.TypedEventHandler<CoreDragDropManager, CoreDropOperationTargetRequestedEventArgs> TargetRequested;
+        boolean AreConcurrentOperationsEnabled;
+    }
+
+    runtimeclass CoreDropOperationTargetRequestedEventArgs
+    {
+        void SetTarget(CoreDropOperationTarget target);
+    }
+} // Microsoft.Reunion.DragDrop

--- a/specs/dragdrop-api/dragdrop.idl
+++ b/specs/dragdrop-api/dragdrop.idl
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corp. Licensed under the MIT license.
 
-namespace Microsoft.ProjectReunion.ApplicationModel.DragDrop
+namespace Microsoft.ProjectReunion.ApplicationModel
 {
     // Forward declare
     runtimeclass DragInfo;
@@ -66,12 +66,12 @@ namespace Microsoft.ProjectReunion.ApplicationModel.DragDrop
 
     runtimeclass DragDropManager
     {
-        DragDropManager GetForCurrentWindow();
+        static DragDropManager GetForCurrentWindow();
         event Windows.Foundation.TypedEventHandler<DragDropManager, DropOperationTargetRequestedEventArgs> TargetRequested;
     }
 
     runtimeclass DropOperationTargetRequestedEventArgs
     {
-        DropOperationTarget DropTarget { set; };
+        void SetTarget(IDropOperationTarget target);
     }
 } // Microsoft.ProjectReunion.ApplicationModel.DragDrop

--- a/specs/dragdrop-api/dragdrop.idl
+++ b/specs/dragdrop-api/dragdrop.idl
@@ -28,10 +28,10 @@ namespace Microsoft.ProjectReunion.ApplicationModel.DragDrop
 
     runtimeclass DragInfo
     {
-        Microsoft.Reunion.ApplicationModel.DataPackage Data { get; };
+        Microsoft.ProjectReunion.ApplicationModel.DataPackage Data { get; };
         DragDropModifiers Modifiers { get; };
         Windows.Foundation.Point Position { get; };
-        Microsoft.Reunion.ApplicationModel.DataPackage.DataPackageOperation AllowedOperations { get; };
+        Microsoft.ProjectReunion.ApplicationModel.DataPackage.DataPackageOperation AllowedOperations { get; };
     }
 
     runtimeclass DragUIOverride
@@ -47,32 +47,31 @@ namespace Microsoft.ProjectReunion.ApplicationModel.DragDrop
 
     interface IDropOperationTarget
     {
-        Windows.Foundation.IAsyncOperation<Microsoft.Reunion.ApplicationModel.DataPackageOperation> EnterAsync(DragInfo dragInfo, DragUIOverride dragUIOverride);
-        Windows.Foundation.IAsyncOperation<Microsoft.Reunion.ApplicationModel.DataPackageOperation> OverAsync(DragInfo dragInfo, DragUIOverride dragUIOverride);
+        Windows.Foundation.IAsyncOperation<Microsoft.ProjectReunion.ApplicationModel.DataPackageOperation> EnterAsync(DragInfo dragInfo, DragUIOverride dragUIOverride);
+        Windows.Foundation.IAsyncOperation<Microsoft.ProjectReunion.ApplicationModel.DataPackageOperation> OverAsync(DragInfo dragInfo, DragUIOverride dragUIOverride);
         Windows.Foundation.IAsyncAction LeaveAsync(DragInfo dragInfo);
-        Windows.Foundation.IAsyncOperation<Microsoft.Reunion.ApplicationModel.DataPackageOperation> DropAsync(DragInfo dragInfo);
+        Windows.Foundation.IAsyncOperation<Microsoft.ProjectReunion.ApplicationModel.DataPackageOperation> DropAsync(DragInfo dragInfo);
     }
 
     runtimeclass DragOperation
     {
-        Microsoft.Reunion.ApplicationModel.DataPackageOperation AllowedOperations;
-        Microsoft.Reunion.ApplicationModel.DataPackage Data { get; };
+        Microsoft.ProjectReunion.ApplicationModel.DataPackageOperation AllowedOperations;
+        Microsoft.ProjectReunion.ApplicationModel.DataPackage Data { get; };
         DragUIContentMode DragUIContentMode;
         void SetPointerId(UInt32 pointerId);
         void SetDragUIContentFromSoftwareBitmap(Windows.Graphics.Imaging.SoftwareBitmap softwareBitmap);
         void SetDragUIContentFromSoftwareBitmapWithAnchorPoint(Windows.Graphics.Imaging.SoftwareBitmap softwareBitmap, Windows.Foundation.Point anchorPoint);
-        Windows.Foundation.IAsyncOperation<Microsoft.Reunion.ApplicationModel.DataPackageOperation> StartAsync();
+        Windows.Foundation.IAsyncOperation<Microsoft.ProjectReunion.ApplicationModel.DataPackageOperation> StartAsync();
     }
 
     runtimeclass DragDropManager
     {
         DragDropManager GetForCurrentWindow();
         event Windows.Foundation.TypedEventHandler<DragDropManager, DropOperationTargetRequestedEventArgs> TargetRequested;
-        Boolean AreConcurrentOperationsEnabled;
     }
 
     runtimeclass DropOperationTargetRequestedEventArgs
     {
-        void SetTarget(DropOperationTarget target);
+        DropOperationTarget DropTarget { set; };
     }
 } // Microsoft.ProjectReunion.ApplicationModel.DragDrop

--- a/specs/dragdrop-api/dragdrop.idl
+++ b/specs/dragdrop-api/dragdrop.idl
@@ -74,4 +74,4 @@ namespace Microsoft.ProjectReunion.ApplicationModel
     {
         void SetTarget(IDropOperationTarget target);
     }
-} // Microsoft.ProjectReunion.ApplicationModel.DragDrop
+} // Microsoft.ProjectReunion.ApplicationModel


### PR DESCRIPTION
This is a proposal spec for a drag & drop API in the Project Reunion SDK.

In this initial version, it is mostly a thin wrapper around the Windows SDK [UWP drag & drop API](https://docs.microsoft.com/en-us/uwp/api/windows.applicationmodel.datatransfer.dragdrop.core?view=winrt-19041) with internal improvements to the implementation to make it callable from _all_ Windows apps; notably from Win32 apps. This gives these apps a path to a modern drag & drop experience on Windows (as opposed to the classic [OLE drag & drop](https://docs.microsoft.com/en-us/windows/win32/com/drag-and-drop) which is much more cumbersome to work with) with easily customizable UI for both drag source and drop target. It also allows us to iterate faster on improvements in the future.

Prior discussion: #70

We greatly appreciate feedback!