### PR TITLE
User/eho makai/reunion metapackage

### DIFF
--- a/build/NuSpecs/ProjectReunionMetaPackage.nuspec
+++ b/build/NuSpecs/ProjectReunionMetaPackage.nuspec
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>$ID$</id>
+    <version>0.0.0-SpecifyVersionOnCommandline</version>
+    <title>Microsoft Project Reunion Meta Package</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <description>Project Reunion Meta Package</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <tags>Windows Reunion ProjectReunion</tags>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <license type="file">license.txt</license>
+    <projectUrl>https://github.com/microsoft/projectreunion</projectUrl>
+    <iconUrl>https://aka.ms/winui_icon</iconUrl>
+  </metadata>
+  <files>
+    <file src="readme.txt"/>
+    <file src="license.txt"/>
+
+    <file target="runtimes" src="$RUNTIMESDIR$\**\*.*"/>
+
+    <!-- Common build logic -->
+    <file target="build\$ID$.targets" src="ProjectReunion-Nuget-Common.targets"/>
+    <file target="buildTransitive\$ID$.targets" src="ProjectReunion-Nuget-Common.targets"/>
+
+    <!-- This is here for C++ based projects, see http://nugetdocsbeta.azurewebsites.net/ndocs/guides/create-uwp-packages -->
+    <file target="build\native\$ID$.targets" src="ProjectReunion-Nuget-Native.targets"/>
+  </files>
+  <dependencies> 
+    <!-- List all Project Reunion references here, please maintain in alphabetical order-->
+    <dependency id="Win2D.uwp" version="1.25.0"/>
+  </dependencies>
+</package>

--- a/build/NuSpecs/ProjectReunionMetaPackage.nuspec
+++ b/build/NuSpecs/ProjectReunionMetaPackage.nuspec
@@ -13,6 +13,10 @@
     <license type="file">license.txt</license>
     <projectUrl>https://github.com/microsoft/projectreunion</projectUrl>
     <iconUrl>https://aka.ms/winui_icon</iconUrl>
+    <dependencies> 
+      <!-- List all Project Reunion references here, please maintain in alphabetical order-->
+      <dependency id="Win2D.uwp" version="1.25.0"/>
+    </dependencies>
   </metadata>
   <files>
     <file src="readme.txt"/>
@@ -27,8 +31,4 @@
     <!-- This is here for C++ based projects, see http://nugetdocsbeta.azurewebsites.net/ndocs/guides/create-uwp-packages -->
     <file target="build\native\$ID$.targets" src="ProjectReunion-Nuget-Native.targets"/>
   </files>
-  <dependencies> 
-    <!-- List all Project Reunion references here, please maintain in alphabetical order-->
-    <dependency id="Win2D.uwp" version="1.25.0"/>
-  </dependencies>
 </package>

--- a/build/NuSpecs/build-nupkg.ps1
+++ b/build/NuSpecs/build-nupkg.ps1
@@ -134,6 +134,8 @@ Write-Host
 #
 
 $nupkgtitle = "Microsoft.ProjectReunion.MetaPackage"
+$CommonNugetArgs = "-properties `"BuildOutput=$BuildOutput``;ID=$nupkgtitle``;RUNTIMESDIR=$runtimesDir`;TOOLSDIR=$toolsDir`;BUILDFLAVOR=$($BuildFlavor)`;BUILDARCH=$($BuildArch)`""
+$NugetArgs = "$CommonNugetArgs -OutputDirectory $OutputDir"
 
 $nugetExe = "$scriptDirectory\..\..\tools\NugetWrapper.cmd"
 $NugetCmdLine = "$nugetExe pack ProjectReunionMetaPackage.nuspec $NugetArgs -version $version"

--- a/build/NuSpecs/build-nupkg.ps1
+++ b/build/NuSpecs/build-nupkg.ps1
@@ -113,8 +113,31 @@ $CommonNugetArgs = "-properties `"BuildOutput=$BuildOutput``;ID=$nupkgtitle``;RU
 
 $NugetArgs = "$CommonNugetArgs -OutputDirectory $OutputDir"
 
+#
+# Build Project Reunion package (with actual contents, i.e. not metapackage)
+#
+
 $nugetExe = "$scriptDirectory\..\..\tools\NugetWrapper.cmd"
 $NugetCmdLine = "$nugetExe pack ProjectReunion.nuspec $NugetArgs -version $version"
+Write-Host 'Building Project Reunion package'
+Write-Host $NugetCmdLine
+Invoke-Expression $NugetCmdLine
+if ($lastexitcode -ne 0)
+{
+    Write-Host "Nuget returned $lastexitcode"
+    Exit $lastexitcode; 
+}
+Write-Host
+
+#
+# Build Project Reunion package meta package (no direct contents, only references)
+#
+
+$nupkgtitle = "Microsoft.ProjectReunion.MetaPackage"
+
+$nugetExe = "$scriptDirectory\..\..\tools\NugetWrapper.cmd"
+$NugetCmdLine = "$nugetExe pack ProjectReunionMetaPackage.nuspec $NugetArgs -version $version"
+Write-Host 'Building Project Reunion Meta Package'
 Write-Host $NugetCmdLine
 Invoke-Expression $NugetCmdLine
 if ($lastexitcode -ne 0)


### PR DESCRIPTION
Added a ProjectReunionMetaPackage.nuspec file and added build steps to build it and publish it to artifacts/drop.  For now it has a single reference for the Win2d.uwp Nuget package (version 1.25.0).  

Tested by taking the Win2d "simple sample", removing the Win2D reference, downloading the build artifact, setting up a nuget package source to a local directory and then installing and referencing the Microsoft.ProjectReunion.MetaPackage nuget package and building the sample.  

Once we publish the ProjectReunion nuget package (the one with actual contents) we can reference it but publishing has not occurred yet. 