### PR TITLE
Changed ResourceMap API to follow WinRT conventions.

### DIFF
--- a/dev/MRTCore/TestApps/winui_desktop_packaged_app/winui_desktop_packaged_app/MainWindow.xaml.cs
+++ b/dev/MRTCore/TestApps/winui_desktop_packaged_app/winui_desktop_packaged_app/MainWindow.xaml.cs
@@ -52,7 +52,7 @@ namespace winui_desktop_packaged_app
         {
             // The resource manager does not have a default scope and resolves resources based on the root.
 
-            var resourceCandidate = m_resourceManager.MainResourceMap.GetValue(m_resourceContext, "Resources/SampleString");
+            var resourceCandidate = m_resourceManager.MainResourceMap.GetValue("Resources/SampleString", m_resourceContext);
             var resourceString = resourceCandidate.ValueAsString;
 
             output.Text = resourceString;

--- a/dev/MRTCore/TestApps/winui_desktop_packaged_app_cpp/winui_desktop_packaged_app_cpp/App.cpp
+++ b/dev/MRTCore/TestApps/winui_desktop_packaged_app_cpp/winui_desktop_packaged_app_cpp/App.cpp
@@ -51,7 +51,7 @@ void App::OnLaunched(LaunchActivatedEventArgs const&)
     m_resourceManagerWinRT = ResourceManager(L"resources.pri");
     check_hresult(MrmCreateResourceManager(L"resources.pri", &m_resourceManagerMrm));
 
-    m_resourceManagerWinRT.ResourceNotFound([](ResourceManager sender, ResourceNotFoundEventArgs args)
+    m_resourceManagerWinRT.ResourceNotFound([](ResourceManager const&, ResourceNotFoundEventArgs const& args)
         {
             // There could be a resource in a legacy resource file that we retrieve using the corresponding legacy resource loader. For example, the C#
             // app in this repo uses the .NET resource loader as its fallback. Instead, we just hardcode a resource value here.

--- a/dev/MRTCore/TestApps/winui_desktop_packaged_app_cpp/winui_desktop_packaged_app_cpp/MainWindow.cpp
+++ b/dev/MRTCore/TestApps/winui_desktop_packaged_app_cpp/winui_desktop_packaged_app_cpp/MainWindow.cpp
@@ -34,16 +34,6 @@ namespace winrt::winui_desktop_packaged_app_cpp::implementation
         check_hresult(MrmSetQualifier(m_overrideResourceContextMrm, L"Language", L"de-DE"));
     }
 
-    int32_t MainWindow::MyProperty()
-    {
-        throw hresult_not_implemented();
-    }
-
-    void MainWindow::MyProperty(int32_t /* value */)
-    {
-        throw hresult_not_implemented();
-    }
-
     void MainWindow::defaultWinrtApi_Click(IInspectable const&, RoutedEventArgs const&)
     {
         auto stringResourceCandidate = m_resourceManagerWinRT.MainResourceMap().GetValue(L"Resources/SampleString");
@@ -52,7 +42,7 @@ namespace winrt::winui_desktop_packaged_app_cpp::implementation
 
     void MainWindow::overrideWinrtApi_Click(IInspectable const&, RoutedEventArgs const&)
     {
-        auto stringResourceCandidate = m_resourceManagerWinRT.MainResourceMap().GetValue(m_overrideResourceContext, L"Resources/SampleString");
+        auto stringResourceCandidate = m_resourceManagerWinRT.MainResourceMap().GetValue(L"Resources/SampleString", m_overrideResourceContext);
         output().Text(stringResourceCandidate.ValueAsString());
     }
 

--- a/dev/MRTCore/TestApps/winui_desktop_packaged_app_cpp/winui_desktop_packaged_app_cpp/MainWindow.h
+++ b/dev/MRTCore/TestApps/winui_desktop_packaged_app_cpp/winui_desktop_packaged_app_cpp/MainWindow.h
@@ -7,8 +7,8 @@
 
 #pragma pop_macro("GetCurrentTime")
 
-#include "MRM.h"
-#include "winrt/Microsoft.ApplicationModel.resources.h"
+#include <MRM.h>
+#include <winrt/Microsoft.ApplicationModel.Resources.h>
 
 namespace winrt::winui_desktop_packaged_app_cpp::implementation
 {
@@ -18,9 +18,6 @@ namespace winrt::winui_desktop_packaged_app_cpp::implementation
         ~MainWindow();
 
         void InitializeResourceLoaders(winrt::Microsoft::ApplicationModel::Resources::ResourceManager resourceManagerWinRT, MrmManagerHandle resourceManagerMrm);        
-
-        int32_t MyProperty();
-        void MyProperty(int32_t value);
 
         void defaultWinrtApi_Click(Windows::Foundation::IInspectable const& sender, Microsoft::UI::Xaml::RoutedEventArgs const& args);
         void overrideWinrtApi_Click(Windows::Foundation::IInspectable const& sender, Microsoft::UI::Xaml::RoutedEventArgs const& args);

--- a/dev/MRTCore/TestApps/winui_desktop_packaged_app_cpp/winui_desktop_packaged_app_cpp/MainWindow.idl
+++ b/dev/MRTCore/TestApps/winui_desktop_packaged_app_cpp/winui_desktop_packaged_app_cpp/MainWindow.idl
@@ -1,9 +1,8 @@
-namespace winui_desktop_packaged_app_cpp
+﻿namespace winui_desktop_packaged_app_cpp
 {
     [default_interface]
     runtimeclass MainWindow : Microsoft.UI.Xaml.Window
     {
         MainWindow();
-        Int32 MyProperty;
     }
 }

--- a/dev/MRTCore/TestApps/winui_desktop_packaged_app_cpp/winui_desktop_packaged_app_cpp/packages.config
+++ b/dev/MRTCore/TestApps/winui_desktop_packaged_app_cpp/winui_desktop_packaged_app_cpp/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationModel.Resources" version="1.0.0-CI-20200915-045934" targetFramework="native" />
+  <package id="Microsoft.ApplicationModel.Resources" version="1.0.0-CI-20200916-181435" targetFramework="native" />
   <package id="Microsoft.VCRTForwarders.140" version="1.0.6" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.200316.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.200729.8" targetFramework="native" />
   <package id="Microsoft.WinUI" version="3.0.0-preview2.200713.0" targetFramework="native" />
 </packages>

--- a/dev/MRTCore/TestApps/winui_desktop_packaged_app_cpp/winui_desktop_packaged_app_cpp/winui_desktop_packaged_app_cpp.vcxproj
+++ b/dev/MRTCore/TestApps/winui_desktop_packaged_app_cpp/winui_desktop_packaged_app_cpp/winui_desktop_packaged_app_cpp.vcxproj
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Microsoft.ApplicationModel.Resources.1.0.0-CI-20200915-045934\build\Microsoft.ApplicationModel.Resources.props" Condition="Exists('..\packages\Microsoft.ApplicationModel.Resources.1.0.0-CI-20200915-045934\build\Microsoft.ApplicationModel.Resources.props')" />
+  <Import Project="..\packages\Microsoft.ApplicationModel.Resources.1.0.0-CI-20200916-181435\build\Microsoft.ApplicationModel.Resources.props" Condition="Exists('..\packages\Microsoft.ApplicationModel.Resources.1.0.0-CI-20200916-181435\build\Microsoft.ApplicationModel.Resources.props')" />
+  <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props')" />
   <Import Project="..\packages\Microsoft.WinUI.3.0.0-preview2.200713.0\build\native\Microsoft.WinUI.props" Condition="Exists('..\packages\Microsoft.WinUI.3.0.0-preview2.200713.0\build\native\Microsoft.WinUI.props')" />
-  <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
@@ -136,21 +136,21 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets')" />
     <Import Project="..\packages\Microsoft.WinUI.3.0.0-preview2.200713.0\build\native\Microsoft.WinUI.targets" Condition="Exists('..\packages\Microsoft.WinUI.3.0.0-preview2.200713.0\build\native\Microsoft.WinUI.targets')" />
     <Import Project="..\packages\Microsoft.VCRTForwarders.140.1.0.6\build\native\Microsoft.VCRTForwarders.140.targets" Condition="Exists('..\packages\Microsoft.VCRTForwarders.140.1.0.6\build\native\Microsoft.VCRTForwarders.140.targets')" />
-    <Import Project="..\packages\Microsoft.ApplicationModel.Resources.1.0.0-CI-20200915-045934\build\Microsoft.ApplicationModel.Resources.targets" Condition="Exists('..\packages\Microsoft.ApplicationModel.Resources.1.0.0-CI-20200915-045934\build\Microsoft.ApplicationModel.Resources.targets')" />
+    <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\packages\Microsoft.ApplicationModel.Resources.1.0.0-CI-20200916-181435\build\Microsoft.ApplicationModel.Resources.targets" Condition="Exists('..\packages\Microsoft.ApplicationModel.Resources.1.0.0-CI-20200916-181435\build\Microsoft.ApplicationModel.Resources.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.WinUI.3.0.0-preview2.200713.0\build\native\Microsoft.WinUI.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.WinUI.3.0.0-preview2.200713.0\build\native\Microsoft.WinUI.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.WinUI.3.0.0-preview2.200713.0\build\native\Microsoft.WinUI.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.WinUI.3.0.0-preview2.200713.0\build\native\Microsoft.WinUI.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.VCRTForwarders.140.1.0.6\build\native\Microsoft.VCRTForwarders.140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VCRTForwarders.140.1.0.6\build\native\Microsoft.VCRTForwarders.140.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.ApplicationModel.Resources.1.0.0-CI-20200915-045934\build\Microsoft.ApplicationModel.Resources.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ApplicationModel.Resources.1.0.0-CI-20200915-045934\build\Microsoft.ApplicationModel.Resources.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.ApplicationModel.Resources.1.0.0-CI-20200915-045934\build\Microsoft.ApplicationModel.Resources.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ApplicationModel.Resources.1.0.0-CI-20200915-045934\build\Microsoft.ApplicationModel.Resources.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.ApplicationModel.Resources.1.0.0-CI-20200916-181435\build\Microsoft.ApplicationModel.Resources.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ApplicationModel.Resources.1.0.0-CI-20200916-181435\build\Microsoft.ApplicationModel.Resources.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.ApplicationModel.Resources.1.0.0-CI-20200916-181435\build\Microsoft.ApplicationModel.Resources.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ApplicationModel.Resources.1.0.0-CI-20200916-181435\build\Microsoft.ApplicationModel.Resources.targets'))" />
   </Target>
 </Project>

--- a/dev/MRTCore/mrt/Microsoft.ApplicationModel.Resources/src/Microsoft.ApplicationModel.Resources.idl
+++ b/dev/MRTCore/mrt/Microsoft.ApplicationModel.Resources/src/Microsoft.ApplicationModel.Resources.idl
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
 namespace Microsoft.ApplicationModel.Resources
@@ -47,9 +47,9 @@ namespace Microsoft.ApplicationModel.Resources
 
         ResourceMap GetSubtree(String reference);
         ResourceCandidate GetValue(String resource);
-        ResourceCandidate GetValue(ResourceContext context, String resource);
+        ResourceCandidate GetValue(String resource, ResourceContext context);
         Windows.Foundation.Collections.IKeyValuePair<String, ResourceCandidate> GetValueByIndex(UInt32 index);
-        Windows.Foundation.Collections.IKeyValuePair<String, ResourceCandidate> GetValueByIndex(ResourceContext context, UInt32 index);
+        Windows.Foundation.Collections.IKeyValuePair<String, ResourceCandidate> GetValueByIndex(UInt32 index, ResourceContext context);
     }
 
     [contract(MrtContract, 1.0)]

--- a/dev/MRTCore/mrt/Microsoft.ApplicationModel.Resources/src/Microsoft.ApplicationModel.Resources.vcxproj
+++ b/dev/MRTCore/mrt/Microsoft.ApplicationModel.Resources/src/Microsoft.ApplicationModel.Resources.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.200615.7\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.200615.7\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
@@ -163,13 +163,13 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.200615.7\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.200615.7\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.200615.7\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.200615.7\build\native\Microsoft.Windows.CppWinRT.props'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.200615.7\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.200615.7\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets'))" />
   </Target>
 </Project>

--- a/dev/MRTCore/mrt/Microsoft.ApplicationModel.Resources/src/ResourceMap.cpp
+++ b/dev/MRTCore/mrt/Microsoft.ApplicationModel.Resources/src/ResourceMap.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
 #include "pch.h"
@@ -117,9 +117,12 @@ Resources::ResourceCandidate ResourceMap::GetValueImpl(const Resources::Resource
     winrt::throw_hresult(E_UNEXPECTED);
 }
 
-Resources::ResourceCandidate ResourceMap::GetValue(hstring const& resource) { return GetValueImpl(nullptr, resource); }
+Resources::ResourceCandidate ResourceMap::GetValue(hstring const& resource)
+{
+    return GetValueImpl(nullptr, resource);
+}
 
-Resources::ResourceCandidate ResourceMap::GetValue(Resources::ResourceContext const& context, hstring const& resource)
+Resources::ResourceCandidate ResourceMap::GetValue(hstring const& resource, Resources::ResourceContext const& context)
 {
     return GetValueImpl(&context, resource);
 }
@@ -208,7 +211,7 @@ IKeyValuePair<hstring, Resources::ResourceCandidate> ResourceMap::GetValueByInde
     return GetValueByIndexImpl(nullptr, index);
 }
 
-IKeyValuePair<hstring, Resources::ResourceCandidate> ResourceMap::GetValueByIndex(Resources::ResourceContext const& context, uint32_t index)
+IKeyValuePair<hstring, Resources::ResourceCandidate> ResourceMap::GetValueByIndex(uint32_t index, Resources::ResourceContext const& context)
 {
     return GetValueByIndexImpl(&context, index);
 }

--- a/dev/MRTCore/mrt/Microsoft.ApplicationModel.Resources/src/ResourceMap.h
+++ b/dev/MRTCore/mrt/Microsoft.ApplicationModel.Resources/src/ResourceMap.h
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
 #pragma once
@@ -26,15 +26,15 @@ struct ResourceMap : ResourceMapT<ResourceMap>
     Microsoft::ApplicationModel::Resources::ResourceCandidate GetValue(hstring const& resource);
 
     Microsoft::ApplicationModel::Resources::ResourceCandidate GetValue(
-        Microsoft::ApplicationModel::Resources::ResourceContext const& context,
-        hstring const& resource);
+        hstring const& resource,
+        Microsoft::ApplicationModel::Resources::ResourceContext const& context);
 
     Windows::Foundation::Collections::IKeyValuePair<hstring, Microsoft::ApplicationModel::Resources::ResourceCandidate> GetValueByIndex(
         uint32_t index);
 
     Windows::Foundation::Collections::IKeyValuePair<hstring, Microsoft::ApplicationModel::Resources::ResourceCandidate> GetValueByIndex(
-        Microsoft::ApplicationModel::Resources::ResourceContext const& context,
-        uint32_t index);
+        uint32_t index,
+        Microsoft::ApplicationModel::Resources::ResourceContext const& context);
 
 private:
     Microsoft::ApplicationModel::Resources::ResourceCandidate GetValueImpl(

--- a/dev/MRTCore/mrt/Microsoft.ApplicationModel.Resources/src/packages.config
+++ b/dev/MRTCore/mrt/Microsoft.ApplicationModel.Resources/src/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.200615.7" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.200729.8" targetFramework="native" />
 </packages>

--- a/dev/MRTCore/mrt/Microsoft.ApplicationModel.Resources/unittests/UnitTest.cs
+++ b/dev/MRTCore/mrt/Microsoft.ApplicationModel.Resources/unittests/UnitTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
 using System;
@@ -205,7 +205,7 @@ namespace ManagedTest
             var resourceContext = resourceManager.CreateResourceContext();
             var qualifierValues = resourceContext.QualifierValues;
 
-            var resourceCandidate = resourceManager.MainResourceMap.GetValue(resourceContext, "resources/IDS_WHATS_NEW_1710_2_EQUALIZER_TITLE");
+            var resourceCandidate = resourceManager.MainResourceMap.GetValue("resources/IDS_WHATS_NEW_1710_2_EQUALIZER_TITLE", resourceContext);
             var resource = resourceCandidate.ValueAsString;
             if ((qualifierValues[KnownResourceQualifierName.Language].IndexOf("en-US") != -1) || (qualifierValues[KnownResourceQualifierName.Language].IndexOf("en") == -1))
             {
@@ -216,14 +216,14 @@ namespace ManagedTest
             Assert.AreEqual(qualifierValues[KnownResourceQualifierName.Scale], "");
 
             qualifierValues[KnownResourceQualifierName.Language] = "en-GB";
-            resourceCandidate = resourceManager.MainResourceMap.GetValue(resourceContext, "resources/IDS_WHATS_NEW_1710_2_EQUALIZER_TITLE");
+            resourceCandidate = resourceManager.MainResourceMap.GetValue("resources/IDS_WHATS_NEW_1710_2_EQUALIZER_TITLE", resourceContext);
             resource = resourceCandidate.ValueAsString;
             Assert.AreEqual(resource, "Equaliser");
             Assert.AreEqual(resourceCandidate.QualifierValues[KnownResourceQualifierName.Language], "EN-GB");
             Assert.IsFalse(resourceCandidate.QualifierValues.ContainsKey(KnownResourceQualifierName.Scale));
 
             qualifierValues[KnownResourceQualifierName.Language] = "en-AU";
-            resourceCandidate = resourceManager.MainResourceMap.GetValue(resourceContext, "resources/IDS_WHATS_NEW_1710_2_EQUALIZER_TITLE");
+            resourceCandidate = resourceManager.MainResourceMap.GetValue("resources/IDS_WHATS_NEW_1710_2_EQUALIZER_TITLE", resourceContext);
             resource = resourceCandidate.ValueAsString;
             Assert.AreEqual(resource, "Equaliser");
             // Candidate for en-GB is selected
@@ -241,7 +241,7 @@ namespace ManagedTest
 
             resourceContext.QualifierValues[KnownResourceQualifierName.Contrast] = "White";
             resourceContext.QualifierValues[KnownResourceQualifierName.TargetSize] = "96";
-            var resourceCandidate = resourceManager.MainResourceMap.GetValue(resourceContext, "Files/Assets/AppList.png");
+            var resourceCandidate = resourceManager.MainResourceMap.GetValue("Files/Assets/AppList.png", resourceContext);
             var resource = resourceCandidate.ValueAsString;
             Assert.AreNotEqual(resource.IndexOf(@"Assets\contrast-white\AppList.targetsize-96_contrast-white.png"), -1);
             Assert.AreEqual(resourceCandidate.QualifierValues[KnownResourceQualifierName.Contrast], "WHITE");
@@ -250,7 +250,7 @@ namespace ManagedTest
             resourceContext.QualifierValues[KnownResourceQualifierName.Contrast] = "Black";
             resourceContext.QualifierValues[KnownResourceQualifierName.TargetSize] = "72";
             resourceContext.QualifierValues["AlternateForm"] = "UNPLATED";
-            resourceCandidate = resourceManager.MainResourceMap.GetValue(resourceContext, "Files/Assets/AppList.png");
+            resourceCandidate = resourceManager.MainResourceMap.GetValue("Files/Assets/AppList.png", resourceContext);
             resource = resourceCandidate.ValueAsString;
             Assert.AreNotEqual(resource.IndexOf(@"Assets\contrast-black\AppList.targetsize-72_altform-unplated_contrast-black.png"), -1);
             Assert.AreEqual(resourceCandidate.QualifierValues[KnownResourceQualifierName.Contrast], "BLACK");
@@ -271,7 +271,7 @@ namespace ManagedTest
             resourceContext.QualifierValues[KnownResourceQualifierName.Language] = "en-US";
 
             // first resource under the resource map
-            var value = resourceMap.GetValueByIndex(resourceContext, 0);
+            var value = resourceMap.GetValueByIndex(0, resourceContext);
             Assert.AreEqual(value.Key, "000D1359");
             var candidate = value.Value;
             Assert.AreEqual(candidate.ValueAsString, "This song is available only when you buy the whole album.");
@@ -279,7 +279,7 @@ namespace ManagedTest
             Assert.AreEqual(candidate.QualifierValues[KnownResourceQualifierName.Language], "EN-US");
 
             // second to last resource under the resource map
-            value = resourceMap.GetValueByIndex(resourceContext, 1267);
+            value = resourceMap.GetValueByIndex(1267, resourceContext);
             Assert.AreEqual(value.Key, "IDS_WHATS_NEW_1710_2_EQUALIZER_TITLE");
             candidate = value.Value;
             Assert.AreEqual(candidate.ValueAsString, "Equalizer");
@@ -289,7 +289,7 @@ namespace ManagedTest
             resourceContext.QualifierValues[KnownResourceQualifierName.Language] = "en-GB";
 
             // first resource under the resource map
-            value = resourceMap.GetValueByIndex(resourceContext, 0);
+            value = resourceMap.GetValueByIndex(0, resourceContext);
             Assert.AreEqual(value.Key, "000D1359");
             candidate = value.Value;
             Assert.AreEqual(candidate.ValueAsString, "This song is available only when you buy the whole album.");
@@ -297,7 +297,7 @@ namespace ManagedTest
             Assert.AreEqual(candidate.QualifierValues[KnownResourceQualifierName.Language], "EN-GB");
 
             // second to last resource under the resource map
-            value = resourceMap.GetValueByIndex(resourceContext, 1267);
+            value = resourceMap.GetValueByIndex(1267, resourceContext);
             Assert.AreEqual(value.Key, "IDS_WHATS_NEW_1710_2_EQUALIZER_TITLE");
             candidate = value.Value;
             Assert.AreEqual(candidate.ValueAsString, "Equaliser");
@@ -333,19 +333,19 @@ namespace ManagedTest
             var resourceContext = resourceManager.CreateResourceContext();
             resourceContext.QualifierValues[KnownResourceQualifierName.Language] = "en-US";
             var resourceMap = resourceManager.MainResourceMap.GetSubtree("resources");
-            var resourceCandidate = resourceMap.GetValue(resourceContext, "abc");
+            var resourceCandidate = resourceMap.GetValue("abc", resourceContext);
             var resource = resourceCandidate.ValueAsString;
             Assert.AreEqual(resource, "USValue");
             Assert.AreEqual(resourceCandidate.QualifierValues[KnownResourceQualifierName.Language], "en-US");
 
             resourceContext.QualifierValues[KnownResourceQualifierName.Language] = "en-GB";
-            resourceCandidate = resourceMap.GetValue(resourceContext, "abc");
+            resourceCandidate = resourceMap.GetValue("abc", resourceContext);
             resource = resourceCandidate.ValueAsString;
             Assert.AreEqual(resource, "GBValue");
             Assert.AreEqual(resourceCandidate.QualifierValues[KnownResourceQualifierName.Language], "en-GB");
 
             resourceContext.QualifierValues[KnownResourceQualifierName.Language] = "fr-FR";
-            resourceCandidate = resourceMap.GetValue(resourceContext, "abc");
+            resourceCandidate = resourceMap.GetValue("abc", resourceContext);
             resource = resourceCandidate.ValueAsString;
             Assert.AreEqual(resource, "OtherValue");
             Assert.AreEqual(resourceCandidate.QualifierValues[KnownResourceQualifierName.Language], "fr-FR");
@@ -395,24 +395,24 @@ namespace ManagedTest
             };
 
             resourceContext.QualifierValues[KnownResourceQualifierName.Language] = "en-US";
-            resourceCandidate = resourceMap.GetValue(resourceContext, "abc");
+            resourceCandidate = resourceMap.GetValue("abc", resourceContext);
             Assert.AreEqual(resourceCandidate.Kind, ResourceCandidateKind.String);
             Assert.AreEqual(resourceCandidate.ValueAsString, "USValue");
             Assert.AreEqual(resourceCandidate.QualifierValues[KnownResourceQualifierName.Language], "en-US");
 
             resourceContext.QualifierValues[KnownResourceQualifierName.Language] = "en-GB";
-            resourceCandidate = resourceMap.GetValue(resourceContext, "abc");
+            resourceCandidate = resourceMap.GetValue("abc", resourceContext);
             Assert.AreEqual(resourceCandidate.Kind, ResourceCandidateKind.String);
             Assert.AreEqual(resourceCandidate.ValueAsString, "GBValue");
             Assert.AreEqual(resourceCandidate.QualifierValues[KnownResourceQualifierName.Language], "en-GB");
 
             resourceContext.QualifierValues[KnownResourceQualifierName.Language] = "fr-FR";
-            resourceCandidate = resourceMap.GetValue(resourceContext, "abc");
+            resourceCandidate = resourceMap.GetValue("abc", resourceContext);
             Assert.AreEqual(resourceCandidate.Kind, ResourceCandidateKind.String);
             Assert.AreEqual(resourceCandidate.ValueAsString, "OtherValue");
             Assert.AreEqual(resourceCandidate.QualifierValues[KnownResourceQualifierName.Language], "fr-FR");
 
-            resourceCandidate = resourceMap.GetValue(resourceContext, "xyz");
+            resourceCandidate = resourceMap.GetValue("xyz", resourceContext);
             Assert.IsNull(resourceCandidate);
         }
     }


### PR DESCRIPTION
Made the `ResourceContext` parameter be the second parameter in the overloads, not the first.

Note: the unit tests run, but for various reasons I can't verify that the two test apps are working correctly. (VS refuses to open the managed project, and the native project needs the NuGet feed to be available and I can't figure out how to build a local version).