### PR TITLE
Decoy change to test PR triggers

### DIFF
--- a/build/AzurePipelinesTemplates/ProjectReunion-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/ProjectReunion-CreateNugetPackage-Job.yml
@@ -110,3 +110,5 @@ jobs:
       command: push
       publishVstsFeed: $(NuGetFeed)
       packagesToPush: $(Build.ArtifactStagingDirectory)/*.nupkg
+
+# Dummy change to test pipeline triggers on PR


### PR DESCRIPTION
This PR will not be completed.  It is only being used to test the PR triggers.

The branch push pipeline should include the verbose dir /s in the CreateNuget logs.

The PR pipeline should not include the verbose dir /s in the CreateNuget logs.