### PR TITLE
User/eho makai/publish nuget private feed

### DIFF
--- a/build/AzurePipelinesTemplates/ProjectReunion-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/ProjectReunion-CreateNugetPackage-Job.yml
@@ -105,7 +105,7 @@ jobs:
     displayName: 'NuGet push to Project.Reunion.nuget.internal'
     inputs:
       command: 'push'
-      packagesToPush: '$(Build.ArtifactStagingDirectory)/drop/*.nupkg'
+      packagesToPush: '${{ parameters.nupkgdir }}\signed\*.nupkg'
       verbosityPush: 'Detailed' 
       nuGetFeedType: 'internal'
       publishVstsFeed: 'Project.Reunion.nuget.internal'

--- a/build/AzurePipelinesTemplates/ProjectReunion-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/ProjectReunion-CreateNugetPackage-Job.yml
@@ -105,10 +105,10 @@ jobs:
     displayName: 'NuGet push to Project.Reunion.nuget.internal'
     inputs:
       command: 'push'
-      packagesToPush: '${{ parameters.nupkgdir }}\**\*.nupkg'
+      packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg;!$(Build.ArtifactStagingDirectory)/**/*.symbols.nupkg'
       verbosityPush: 'Detailed' 
       nuGetFeedType: 'internal'
-      publishVstsFeed: 'Project.Reunion.nuget.internal'
+      publishVstsFeed: 'ProjectReunion/Project.Reunion.nuget.internal'
 
 
 #UNDONE - EHO we need to seed these guid's properly!

--- a/build/AzurePipelinesTemplates/ProjectReunion-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/ProjectReunion-CreateNugetPackage-Job.yml
@@ -99,6 +99,17 @@ jobs:
     inputs:
       PathtoPublish: '${{ parameters.nupkgdir }}'
       artifactName: 'drop'
+      
+    # this mysterious guid fixes the "NuGetCommand@2 is ambiguous" error :-(
+  - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
+    displayName: 'NuGet push to Project.Reunion.nuget.internal'
+    inputs:
+      command: 'push'
+      packagesToPush: '$(Build.ArtifactStagingDirectory)/drop/*.nupkg'
+      verbosityPush: 'Detailed' 
+      nuGetFeedType: 'internal'
+      publishVstsFeed: 'Project.Reunion.nuget.internal'
+
 
 #UNDONE - EHO we need to seed these guid's properly!
 #see, e.g. AzurePipelinesTemplates\ProjectReunion-BuildAndPublishPGONuGet-Job.yml

--- a/build/AzurePipelinesTemplates/ProjectReunion-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/ProjectReunion-CreateNugetPackage-Job.yml
@@ -105,7 +105,7 @@ jobs:
     displayName: 'NuGet push to Project.Reunion.nuget.internal'
     inputs:
       command: 'push'
-      packagesToPush: '${{ parameters.nupkgdir }}\signed\*.nupkg'
+      packagesToPush: '${{ parameters.nupkgdir }}\**\*.nupkg'
       verbosityPush: 'Detailed' 
       nuGetFeedType: 'internal'
       publishVstsFeed: 'Project.Reunion.nuget.internal'

--- a/build/AzurePipelinesTemplates/ProjectReunion-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/ProjectReunion-CreateNugetPackage-Job.yml
@@ -111,7 +111,6 @@ jobs:
       #Note: The project qualifier is always required when using a feed name. Also, do not use organization scoped feeds. 
       publishVstsFeed: 'ProjectReunion/Project.Reunion.nuget.internal'
 
-
 #UNDONE - EHO we need to seed these guid's properly!
 #see, e.g. AzurePipelinesTemplates\ProjectReunion-BuildAndPublishPGONuGet-Job.yml
 #

--- a/build/AzurePipelinesTemplates/ProjectReunion-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/ProjectReunion-CreateNugetPackage-Job.yml
@@ -116,10 +116,11 @@ jobs:
 #
 # To publish the package to vsts feed, set queue time variable NuGetFeed = d62f8eac-f05c-4c25-bccb-21f98b95c95f
 # This is the magic GUID from the pipeline visual designer for this feed: https://dev.azure.com/ms/microsoft-ui-xaml/_packaging?_a=feed&feed=MUX-CI
-  - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
-    condition: and(ne(variables['NuGetFeed'], ''), ne(variables['Build.Reason'], 'Manual'))
-    displayName: 'NuGet push to $(NuGetFeed)'
-    inputs:
-      command: push
-      publishVstsFeed: $(NuGetFeed)
-      packagesToPush: $(Build.ArtifactStagingDirectory)/*.nupkg
+#  - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
+#    condition: and(ne(variables['NuGetFeed'], ''), ne(variables['Build.Reason'], 'Manual'))
+#    displayName: 'NuGet push to $(NuGetFeed)'
+#    inputs:
+#      command: push
+#      publishVstsFeed: $(NuGetFeed)
+#      packagesToPush: $(Build.ArtifactStagingDirectory)/*.nupkg
+

--- a/build/AzurePipelinesTemplates/ProjectReunion-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/ProjectReunion-CreateNugetPackage-Job.yml
@@ -105,9 +105,10 @@ jobs:
     displayName: 'NuGet push to Project.Reunion.nuget.internal'
     inputs:
       command: 'push'
-      packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg;!$(Build.ArtifactStagingDirectory)/**/*.symbols.nupkg'
+      packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg;!$(Build.ArtifactStagingDirectory)/*.symbols.nupkg'
       verbosityPush: 'Detailed' 
       nuGetFeedType: 'internal'
+      #Note: The project qualifier is always required when using a feed name. Also, do not use organization scoped feeds. 
       publishVstsFeed: 'ProjectReunion/Project.Reunion.nuget.internal'
 
 

--- a/build/ProjectReunion-release.yml
+++ b/build/ProjectReunion-release.yml
@@ -169,19 +169,19 @@ jobs:
     useReleaseTag: '$(ProjectReunionFinalRelease)'
     prereleaseVersionTag: prerelease
 
-- job: PushToPrivateNugetFeed
-  dependsOn: CreateNugetPackage
-  pool:
-    vmImage: 'windows-2019'
-  steps:
-    # this mysterious guid fixes the "NuGetCommand@2 is ambiguous" error :-(
-    - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
-      inputs:
-        command: 'push'
-        packagesToPush: '$(Build.ArtifactStagingDirectory)/drop/*.nupkg'
-        verbosityPush: 'Detailed' 
-        nuGetFeedType: 'internal'
-        publishVstsFeed: 'Project.Reunion.nuget.internal'
+#- job: PushToPrivateNugetFeed
+#  dependsOn: CreateNugetPackage
+#  pool:
+#    vmImage: 'windows-2019'
+#  steps:
+#    # this mysterious guid fixes the "NuGetCommand@2 is ambiguous" error :-(
+#    - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
+#      inputs:
+#        command: 'push'
+#        packagesToPush: '$(Build.ArtifactStagingDirectory)/drop/*.nupkg'
+#        verbosityPush: 'Detailed' 
+#        nuGetFeedType: 'internal'
+#        publishVstsFeed: 'Project.Reunion.nuget.internal'
 
 # Build solution that depends on nuget package
 #- template: AzurePipelinesTemplates\ProjectReunion-NugetReleaseTest-Job.yml

--- a/build/ProjectReunion-release.yml
+++ b/build/ProjectReunion-release.yml
@@ -169,6 +169,15 @@ jobs:
     useReleaseTag: '$(ProjectReunionFinalRelease)'
     prereleaseVersionTag: prerelease
 
+- task: NuGetCommand@2
+  jobName: PushNugetToInternalFeed
+  dependsOn: CreateNugetPackage
+  inputs:
+    command: 'push'
+    packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg'
+    nuGetFeedType: 'internal'
+    publishVstsFeed: 'Project.Reunion.nuget.internal'
+
 # Build solution that depends on nuget package
 #- template: AzurePipelinesTemplates\ProjectReunion-NugetReleaseTest-Job.yml
 #  parameters:

--- a/build/ProjectReunion-release.yml
+++ b/build/ProjectReunion-release.yml
@@ -175,12 +175,10 @@ jobs:
     vmImage: 'windows-2019'
   steps:
     # this mysterious guid fixes the "NuGetCommand@2 is ambiguous" error :-(
-    # 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
-    # the piepline run error says use:  .NuGetCommand, .NuGetCommand
     - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
       inputs:
         command: 'push'
-        packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg'
+        packagesToPush: '$(Build.ArtifactStagingDirectory)/drop/*.nupkg'
         nuGetFeedType: 'internal'
         publishVstsFeed: 'Project.Reunion.nuget.internal'
 

--- a/build/ProjectReunion-release.yml
+++ b/build/ProjectReunion-release.yml
@@ -173,13 +173,13 @@ jobs:
   dependsOn: CreateNugetPackage
   pool:
     vmImage: 'windows-2019'
-
-  - task: NuGetCommand@2
-    inputs:
-      command: 'push'
-      packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg'
-      nuGetFeedType: 'internal'
-      publishVstsFeed: 'Project.Reunion.nuget.internal'
+  steps:
+    - task: NuGetCommand@2
+      inputs:
+        command: 'push'
+        packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg'
+        nuGetFeedType: 'internal'
+        publishVstsFeed: 'Project.Reunion.nuget.internal'
 
 # Build solution that depends on nuget package
 #- template: AzurePipelinesTemplates\ProjectReunion-NugetReleaseTest-Job.yml

--- a/build/ProjectReunion-release.yml
+++ b/build/ProjectReunion-release.yml
@@ -169,20 +169,6 @@ jobs:
     useReleaseTag: '$(ProjectReunionFinalRelease)'
     prereleaseVersionTag: prerelease
 
-#- job: PushToPrivateNugetFeed
-#  dependsOn: CreateNugetPackage
-#  pool:
-#    vmImage: 'windows-2019'
-#  steps:
-#    # this mysterious guid fixes the "NuGetCommand@2 is ambiguous" error :-(
-#    - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
-#      inputs:
-#        command: 'push'
-#        packagesToPush: '$(Build.ArtifactStagingDirectory)/drop/*.nupkg'
-#        verbosityPush: 'Detailed' 
-#        nuGetFeedType: 'internal'
-#        publishVstsFeed: 'Project.Reunion.nuget.internal'
-
 # Build solution that depends on nuget package
 #- template: AzurePipelinesTemplates\ProjectReunion-NugetReleaseTest-Job.yml
 #  parameters:

--- a/build/ProjectReunion-release.yml
+++ b/build/ProjectReunion-release.yml
@@ -179,6 +179,7 @@ jobs:
       inputs:
         command: 'push'
         packagesToPush: '$(Build.ArtifactStagingDirectory)/drop/*.nupkg'
+        verbosityPush: 'Detailed' 
         nuGetFeedType: 'internal'
         publishVstsFeed: 'Project.Reunion.nuget.internal'
 

--- a/build/ProjectReunion-release.yml
+++ b/build/ProjectReunion-release.yml
@@ -169,14 +169,17 @@ jobs:
     useReleaseTag: '$(ProjectReunionFinalRelease)'
     prereleaseVersionTag: prerelease
 
-- task: NuGetCommand@2
-  jobName: PushNugetToInternalFeed
+- job: PushToPrivateNugetFeed
   dependsOn: CreateNugetPackage
-  inputs:
-    command: 'push'
-    packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg'
-    nuGetFeedType: 'internal'
-    publishVstsFeed: 'Project.Reunion.nuget.internal'
+  pool:
+    vmImage: 'windows-2019'
+
+  - task: NuGetCommand@2
+    inputs:
+      command: 'push'
+      packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg'
+      nuGetFeedType: 'internal'
+      publishVstsFeed: 'Project.Reunion.nuget.internal'
 
 # Build solution that depends on nuget package
 #- template: AzurePipelinesTemplates\ProjectReunion-NugetReleaseTest-Job.yml

--- a/build/ProjectReunion-release.yml
+++ b/build/ProjectReunion-release.yml
@@ -174,7 +174,10 @@ jobs:
   pool:
     vmImage: 'windows-2019'
   steps:
-    - task: NuGetCommand@2
+    # this mysterious guid fixes the "NuGetCommand@2 is ambiguous" error :-(
+    # 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
+    # the piepline run error says use:  .NuGetCommand, .NuGetCommand
+    - task: .NugetCommand@2
       inputs:
         command: 'push'
         packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg'

--- a/build/ProjectReunion-release.yml
+++ b/build/ProjectReunion-release.yml
@@ -177,7 +177,7 @@ jobs:
     # this mysterious guid fixes the "NuGetCommand@2 is ambiguous" error :-(
     # 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
     # the piepline run error says use:  .NuGetCommand, .NuGetCommand
-    - task: .NugetCommand@2
+    - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
       inputs:
         command: 'push'
         packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg'

--- a/build/ProjectReunion-release.yml
+++ b/build/ProjectReunion-release.yml
@@ -1,8 +1,6 @@
 name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 variables:
   minimumExpectedTestsExecutedCount: 35  # Sanity check for minimum expected tests to be reported
-#n.b. this is a parameter in WinUI-BuildMUXProject-Steps.yml  
-  buildArtifactsDirectory: $(Build.SourcesDirectory)\BuildOutput
   
 jobs:
 


### PR DESCRIPTION
Push the Microsoft.ProjectReunion.*.nupkg to the private nuget feed under the artifacts feed 'ProjectReunion/Microsoft.ProjectReunion.nuget.internal'.  This is for use by WInUI3 for their November preview release to embed in their package.  After this release WinUI will be in the Project Reunion package and this internal nuget drop will no longer be necessary.  

This also pushes the Project Reunion metapackage but this will be ignored. 