### PR TITLE
Remove 19h1 helix queue from test project

### DIFF
--- a/build/Helix/RunTestsInHelix.proj
+++ b/build/Helix/RunTestsInHelix.proj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <HelixSource>pr</HelixSource>
     <HelixType>DevTestSuite</HelixType>
-    <HelixTargetQueues>Windows.10.Amd64.Client19H1.Xaml;Windows.10.Amd64.ClientRS5.Xaml;</HelixTargetQueues>
+    <HelixTargetQueues>Windows.10.Amd64.ClientRS5.Xaml;</HelixTargetQueues>
     <EnableXUnitReporter>true</EnableXUnitReporter>
     <EnableAzurePipelinesReporter>true</EnableAzurePipelinesReporter>
     <HelixPreCommands>$(HelixPreCommands);set testnameprefix=$(Configuration).$(Platform)</HelixPreCommands>

--- a/build/ProjectReunion-CI.yml
+++ b/build/ProjectReunion-CI.yml
@@ -49,7 +49,7 @@ jobs:
   parameters:
     dependsOn: RunTestsInHelix
     rerunPassesRequiredToAvoidFailure: $(rerunPassesRequiredToAvoidFailure)
-    minimumExpectedTestsExecutedCount: 4
+    minimumExpectedTestsExecutedCount: 2
 
 # MRTCore build pipeline
 - template: ..\dev\MRTCore\azure-pipelines.yml


### PR DESCRIPTION
Summary:  this PR removes 19h1 helix queue from the test project.

Details:  I originally set up the helix tests to run on two different queues rs5 and 19h1 (just for the sake of ensuring we can run on multiple queues)  Talking with the helix team last week it sounded like the 19h1 queue was still having issues with scaling. This can cause some of our runs to take over an hour while the rs5 test finishes fast and is stuck waiting for 19h1 to get over whatever scaling issue they are facing.  The quick fix here is to remove 19h1 for now since it's just adding extra iteration time for our devs.  We can look at adding it back when we start looking at release gating and what candidates we need testing on to ensure a stable release.

Watch out for: Reducing the number of tests might cause some errors? I reduced the number of tests we expect to be running to reflect this. Also watch out for... faster pipelines!
