### PR TITLE
Rename nuget package to "full"

### DIFF
--- a/build/AzurePipelinesTemplates/ProjectReunion-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/ProjectReunion-CreateNugetPackage-Job.yml
@@ -3,7 +3,7 @@ parameters:
   jobName: ''
   dependsOn: ''
   buildOutputDir: '$(Build.SourcesDirectory)\BuildOutput'
-  fatnupkgdir: '$(build.artifactStagingDirectory)\fatnuget' 
+  fullnupkgdir: '$(build.artifactStagingDirectory)\fullnuget' 
   thinnupkgdir: '$(build.artifactStagingDirectory)\thinnuget'
   fwpdir: '$(build.artifactStagingDirectory)\fwp'
 # The "primary" build arch is the one that the nuspec gets its winmd, pri, and other neutral files from
@@ -48,7 +48,7 @@ jobs:
       echo parameters.jobName '${{ parameters.jobName }}'
       echo parameters.buildOutputDir '${{ parameters.buildOutputDir }}'
       echo parameters.thinnupkgdir '${{ parameters.thinnupkgdir }}'
-      echo parameters.fatnupkgdir '${{ parameters.fatnupkgdir }}'
+      echo parameters.fullnupkgdir '${{ parameters.fullnupkgdir }}'
       echo parameters.fwpdir '${{ parameters.fwpdir }}'
       echo parameters.publishPath '${{ parameters.publishPath }}'
       echo buildrevision=$(buildrevision)
@@ -58,22 +58,22 @@ jobs:
 
   - task: DownloadBuildArtifacts@0 
     inputs: 
-      artifactName: FatNuget
+      artifactName: FullNuget
       downloadPath: '$(Build.ArtifactStagingDirectory)'
 
   - task: CopyFiles@2
-    displayName: 'copy license to fat nuget'
+    displayName: 'copy license to full nuget'
     inputs:
       SourceFolder: '$(Build.SourcesDirectory)'
       Contents: |
         LICENSE
-      TargetFolder: '${{ parameters.fatnupkgdir }}'
+      TargetFolder: '${{ parameters.fullnupkgdir }}'
 
-  # Extract thin nuget package from fat nuget package
+  # Extract thin nuget package from full nuget package
   - task: CopyFiles@2
-    displayName: 'Extract Thin Nuget from Fat Nuget'
+    displayName: 'Extract Thin Nuget from Full Nuget'
     inputs:
-      SourceFolder: '${{ parameters.fatnupkgdir }}'
+      SourceFolder: '${{ parameters.fullnupkgdir }}'
       Contents: |
         build\**
         include\**
@@ -82,11 +82,11 @@ jobs:
       TargetFolder: '${{ parameters.thinnupkgdir }}'
       flattenFolders: false
 
-  # Extract framework package from fat nuget package
+  # Extract framework package from full nuget package
   - task: CopyFiles@2
-    displayName: 'Extract Framework Package from Fat Nuget into temp Directory'
+    displayName: 'Extract Framework Package from Full Nuget into temp Directory'
     inputs:
-      SourceFolder: '${{ parameters.fatnupkgdir }}'
+      SourceFolder: '${{ parameters.fullnupkgdir }}'
       Contents: |
         runtimes\**
         lib\uap10.0\**
@@ -122,7 +122,7 @@ jobs:
   #   displayName: 'build-nupkg.ps1'
 
   - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
-    displayName: 'Pack Fat Nuget Package'
+    displayName: 'Pack Full Nuget Package'
     inputs:
       command: 'pack'
       packagesToPack: '$(Build.SourcesDirectory)\build\NuSpecs\Microsoft.ProjectReunion.nuspec'
@@ -130,8 +130,8 @@ jobs:
       majorVersion: ${{ parameters.major }}
       minorVersion: ${{ parameters.minor }}
       patchVersion: ${{ parameters.patch }}
-      basePath: '${{ parameters.fatnupkgdir }}'
-      packDestination: ${{ parameters.fatnupkgdir }}
+      basePath: '${{ parameters.fullnupkgdir }}'
+      packDestination: ${{ parameters.fullnupkgdir }}
 
   - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
     displayName: 'Pack Thin Nuget Package'
@@ -152,14 +152,14 @@ jobs:
       displayName: CodeSign
       inputs:
         signConfigXml: ${{ parameters.signConfig }}
-        inPathRoot: '${{ parameters.fatnupkgdir }}'
-        outPathRoot: '${{ parameters.fatnupkgdir }}'
+        inPathRoot: '${{ parameters.fullnupkgdir }}'
+        outPathRoot: '${{ parameters.fullnupkgdir }}'
 
   - task: PublishBuildArtifacts@1
-    displayName: 'Publish artifact: Fat Nuget'
+    displayName: 'Publish artifact: Full Nuget'
     inputs:
-      PathtoPublish: '${{ parameters.fatnupkgdir }}'
-      artifactName: 'FatNuget'
+      PathtoPublish: '${{ parameters.fullnupkgdir }}'
+      artifactName: 'FullNuget'
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish artifact: thin nuget'
@@ -179,7 +179,7 @@ jobs:
       displayName: 'NuGet push to Project.Reunion.nuget.internal'
       inputs:
         command: 'push'
-        packagesToPush: '$(Build.ArtifactStagingDirectory)/fatnuget/*.nupkg;!$(Build.ArtifactStagingDirectory)/fatnuget/*.symbols.nupkg'
+        packagesToPush: '$(Build.ArtifactStagingDirectory)/fullnuget/*.nupkg;!$(Build.ArtifactStagingDirectory)/fullnuget/*.symbols.nupkg'
         verbosityPush: 'Detailed' 
         nuGetFeedType: 'internal'
         #Note: The project qualifier is always required when using a feed name. Also, do not use organization scoped feeds. 

--- a/build/ProjectReunion-release.yml
+++ b/build/ProjectReunion-release.yml
@@ -96,7 +96,7 @@ jobs:
     condition:
       eq(variables['useBuildOutputFromBuildId'],'')
     inputs:
-      artifactName: drop
+      artifactName: FullNuget
       downloadPath: '$(Build.ArtifactStagingDirectory)'
 
   - task: DownloadBuildArtifacts@0
@@ -108,7 +108,7 @@ jobs:
       project: $(System.TeamProjectId)
       pipeline: $(System.DefinitionId)
       buildId: $(useBuildOutputFromBuildId)
-      artifactName: drop
+      artifactName: FullNuget
       downloadPath: '$(Build.ArtifactStagingDirectory)'
 
   - task: CmdLine@1
@@ -125,7 +125,7 @@ jobs:
     displayName: 'Copy symbols to artifact staging directory'
     condition: always()
     inputs:
-      sourceFolder: $(Build.ArtifactStagingDirectory)\drop
+      sourceFolder: $(Build.ArtifactStagingDirectory)\fullnuget
       contents: |
         **\*.pdb
       targetFolder: $(Build.ArtifactStagingDirectory)\symbols
@@ -154,15 +154,15 @@ jobs:
       SYSTEM_ACCESSTOKEN: $(system.accesstoken)
     inputs:
       signConfigXml: '$(Build.SourcesDirectory)\build\SignConfig.xml'
-      inPathRoot: '$(Build.ArtifactStagingDirectory)\drop'
-      outPathRoot: '$(Build.ArtifactStagingDirectory)\drop'
+      inPathRoot: '$(Build.ArtifactStagingDirectory)\fullnuget'
+      outPathRoot: '$(Build.ArtifactStagingDirectory)\fullnuget'
 
-  # Re-publish signed artifacts to the drop.
+  # Re-publish signed artifacts to the fullnuget artifact.
   - task: PublishBuildArtifacts@1
-    displayName: 'Publish artifact: drop'
+    displayName: 'Publish artifact: FullN'
     inputs:
-      PathtoPublish: '$(Build.ArtifactStagingDirectory)\drop'
-      artifactName: 'drop'
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)\fullnuget'
+      artifactName: 'FullNuget'
 
 # Create Nuget Package
 - template: AzurePipelinesTemplates\ProjectReunion-CreateNugetPackage-Job.yml
@@ -181,7 +181,7 @@ jobs:
 #    runTestJobName: 'RunNugetPkgTestsInHelix'
 #    helixType: 'test/nuget'
 #    dependsOn: CreateNugetPackage
-#    pkgArtifactPath: '$(artifactDownloadPath)\drop'
+#    pkgArtifactPath: '$(artifactDownloadPath)\fullnuget'
 
 # Framework package tests
 #- template: AzurePipelinesTemplates\ProjectReunion-NugetReleaseTest-Job.yml
@@ -191,7 +191,7 @@ jobs:
 #    runTestJobName: 'RunFrameworkPkgTestsInHelix'
 #    helixType: 'test/frpkg'
 #    dependsOn: CreateNugetPackage
-#    pkgArtifactPath: '$(artifactDownloadPath)\drop\FrameworkPackage'
+#    pkgArtifactPath: '$(artifactDownloadPath)\fullnuget\FrameworkPackage'
 
 #- template: AzurePipelinesTemplates\ProjectReunion-ProcessTestResults-Job.yml
 #  parameters:

--- a/dev/MRTCore/azure-pipelines.yml
+++ b/dev/MRTCore/azure-pipelines.yml
@@ -295,7 +295,7 @@ jobs:
       SourceFolder: '$(Build.ArtifactStagingDirectory)\mrt_raw\mrtcore_binaries\lib\anycpu'
       Contents: |
         Microsoft.ApplicationModel.Resources.winmd
-      TargetFolder: '$(Build.ArtifactStagingDirectory)\fatnuget\lib\uap10.0\'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)\fullnuget\lib\uap10.0\'
       flattenFolders: true
 
   - task: CopyFiles@2
@@ -305,7 +305,7 @@ jobs:
       Contents: |
         net5.0\Microsoft.ApplicationModel.Resources.Projection.pdb
         net5.0\Microsoft.ApplicationModel.Resources.Projection.dll
-      TargetFolder: '$(Build.ArtifactStagingDirectory)\fatnuget\lib\net5.0-windows\'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)\fullnuget\lib\net5.0-windows\'
       flattenFolders: true
 
   - task: CopyFiles@2
@@ -317,7 +317,7 @@ jobs:
         Microsoft.ApplicationModel.Resources.pdb
         mrm.dll
         Microsoft.ApplicationModel.Resources.dll
-      TargetFolder: '$(Build.ArtifactStagingDirectory)\fatnuget\runtimes\win10-x86\native'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)\fullnuget\runtimes\win10-x86\native'
       flattenFolders: true
 
   - task: CopyFiles@2
@@ -329,7 +329,7 @@ jobs:
         Microsoft.ApplicationModel.Resources.pdb
         mrm.dll
         Microsoft.ApplicationModel.Resources.dll
-      TargetFolder: '$(Build.ArtifactStagingDirectory)\fatnuget\runtimes\win10-x64\native'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)\fullnuget\runtimes\win10-x64\native'
       flattenFolders: true
 
   - task: CopyFiles@2
@@ -341,7 +341,7 @@ jobs:
         Microsoft.ApplicationModel.Resources.pdb
         mrm.dll
         Microsoft.ApplicationModel.Resources.dll
-      TargetFolder: '$(Build.ArtifactStagingDirectory)\fatnuget\runtimes\win10-arm\native'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)\fullnuget\runtimes\win10-arm\native'
       flattenFolders: true
 
   - task: CopyFiles@2
@@ -353,7 +353,7 @@ jobs:
         Microsoft.ApplicationModel.Resources.pdb
         mrm.dll
         Microsoft.ApplicationModel.Resources.dll
-      TargetFolder: '$(Build.ArtifactStagingDirectory)\fatnuget\runtimes\win10-arm64\native'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)\fullnuget\runtimes\win10-arm64\native'
       flattenFolders: true
 
   - task: CopyFiles@2
@@ -362,7 +362,7 @@ jobs:
       SourceFolder: '$(Build.ArtifactStagingDirectory)\mrt_raw\mrtcore_binaries\lib\x86'
       Contents: |
         mrm.lib
-      TargetFolder: '$(Build.ArtifactStagingDirectory)\fatnuget\lib\win10-x86'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)\fullnuget\lib\win10-x86'
       flattenFolders: true
 
   - task: CopyFiles@2
@@ -371,7 +371,7 @@ jobs:
       SourceFolder: '$(Build.ArtifactStagingDirectory)\mrt_raw\mrtcore_binaries\lib\x64'
       Contents: |
         mrm.lib
-      TargetFolder: '$(Build.ArtifactStagingDirectory)\fatnuget\lib\win10-x64'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)\fullnuget\lib\win10-x64'
       flattenFolders: true
 
   - task: CopyFiles@2
@@ -380,7 +380,7 @@ jobs:
       SourceFolder: '$(Build.ArtifactStagingDirectory)\mrt_raw\mrtcore_binaries\lib\ARM'
       Contents: |
         mrm.lib
-      TargetFolder: '$(Build.ArtifactStagingDirectory)\fatnuget\lib\win10-arm'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)\fullnuget\lib\win10-arm'
       flattenFolders: true
 
   - task: CopyFiles@2
@@ -389,7 +389,7 @@ jobs:
       SourceFolder: '$(Build.ArtifactStagingDirectory)\mrt_raw\mrtcore_binaries\lib\ARM64'
       Contents: |
         mrm.lib
-      TargetFolder: '$(Build.ArtifactStagingDirectory)\fatnuget\lib\win10-arm64'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)\fullnuget\lib\win10-arm64'
       flattenFolders: true
 
   - task: CopyFiles@2
@@ -405,7 +405,7 @@ jobs:
         native\Microsoft.ApplicationModel.Resources.targets
         native\Microsoft.ApplicationModel.Resources.WinRt.props
         README.md
-      TargetFolder: '$(Build.ArtifactStagingDirectory)\fatnuget\build'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)\fullnuget\build'
       flattenFolders: false
 
   - task: CopyFiles@2
@@ -414,12 +414,12 @@ jobs:
       SourceFolder: '$(MRTSourcesDirectory)\mrt\core\src'
       Contents: |
         mrm.h
-      TargetFolder: '$(Build.ArtifactStagingDirectory)\fatnuget\include'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)\fullnuget\include'
   
   - task: PublishBuildArtifacts@1
     inputs:
-      PathtoPublish: '$(Build.ArtifactStagingDirectory)\fatnuget'
-      ArtifactName: 'FatNuget'
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)\fullnuget'
+      ArtifactName: 'FullNuget'
 
   # NuGetCommand@2
 #  - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2


### PR DESCRIPTION
Summary:
Mostly a cosmetic change.  We in are in the process of coming up with real names for the different types of nuget packages, but until then, "full" is a better temporary name than "fat".

This changes the yml files, directory structure, and artifact name to reflect that.