### PR TITLE
Add SkipNonexistentTargets param to MSBuild task that calls the GetMrtPackagingOutputs target for referenced projects.

### DIFF
--- a/dev/MRTCore/packaging/Microsoft.ApplicationModel.Resources.PriGen.targets
+++ b/dev/MRTCore/packaging/Microsoft.ApplicationModel.Resources.PriGen.targets
@@ -2102,6 +2102,7 @@
       Condition="'@(ProjectReferenceWithConfiguration)' != ''
                  and '%(ProjectReferenceWithConfiguration.BuildReference)' == 'true'
                  and '%(ProjectReferenceWithConfiguration.ReferenceOutputAssembly)' == 'true'"
+      SkipNonexistentTargets="true"
       ContinueOnError="$(_ContinueOnError)">
       <Output TaskParameter="TargetOutputs" ItemName="_PackagingOutputsFromOtherProjects"/>
     </MSBuild>


### PR DESCRIPTION
Change Description
Add SkipNonexistentTargets param to MSBuild task that calls the GetMrtPackagingOutputs target for referenced projects.

Issue
The targets file recursively calls the GetMrtPackagingOutputs target on referenced projects (this is done to grab all resources, PRI files, etc., from said projects to incorporate into the PRI file that's being generated in the referencing project). The problem is that the GetMrtPackagingOutputs target doesn't exist in projects that don't use MRTCore.

Solution
To address the issue, simply add SkipNonexistentTargets="true" to the MSBuild task invocation!

How verified
App attached to bug now builds successfully.