### PR TITLE
Add PlatformTarget for MRT projection project

### DIFF
--- a/dev/MRTCore/mrt/Microsoft.ApplicationModel.Resources/projection/Microsoft.ApplicationModel.Resources.Projection.csproj
+++ b/dev/MRTCore/mrt/Microsoft.ApplicationModel.Resources/projection/Microsoft.ApplicationModel.Resources.Projection.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net5.0-windows10.0.18362</TargetFrameworks>
     <Platforms>x64;x86</Platforms>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
While loading x86 build of Microsoft.ApplicationModel.Resources.Projection.dll from a .net console app, a System.BadImageFormatException is thrown. Theoretically the projection dll should be architecture neutral. But to avoid this issue, add an explicit PlatformTarget.