### PR TITLE
Master

### DIFF
--- a/dev/MRTCore/mrt/Microsoft.ApplicationModel.Resources/projection/Microsoft.ApplicationModel.Resources.Projection.csproj
+++ b/dev/MRTCore/mrt/Microsoft.ApplicationModel.Resources/projection/Microsoft.ApplicationModel.Resources.Projection.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net5.0-windows10.0.18362</TargetFrameworks>
     <Platforms>x64;x86</Platforms>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dev/MRTCore/packaging/Microsoft.ApplicationModel.Resources.PriGen.targets
+++ b/dev/MRTCore/packaging/Microsoft.ApplicationModel.Resources.PriGen.targets
@@ -2102,6 +2102,7 @@
       Condition="'@(ProjectReferenceWithConfiguration)' != ''
                  and '%(ProjectReferenceWithConfiguration.BuildReference)' == 'true'
                  and '%(ProjectReferenceWithConfiguration.ReferenceOutputAssembly)' == 'true'"
+      SkipNonexistentTargets="true"
       ContinueOnError="$(_ContinueOnError)">
       <Output TaskParameter="TargetOutputs" ItemName="_PackagingOutputsFromOtherProjects"/>
     </MSBuild>


### PR DESCRIPTION
Move last two MRTCore commits in master to main.  

8d8baa5 Add SkipNonexistentTargets param to MSBuild task that calls the GetMrtPackagingOutputs target for referenced projects. (#260)
7954df7 Add PlatformTarget (#261)

