### PR TITLE
Move PublishMRT off Packge ES

### DIFF
--- a/dev/MRTCore/azure-pipelines.yml
+++ b/dev/MRTCore/azure-pipelines.yml
@@ -253,15 +253,9 @@ jobs:
     - BuildMRT
     - SignMRT
   condition: and(in(dependencies.BuildMRT.result, 'Succeeded'), in(dependencies.SignMRT.result, 'Succeeded', 'Skipped'))
+  pool:
+    vmImage: 'windows-latest'
 
-  ${{if eq(parameters.doCodeSign, 'false')}}:
-    pool:
-      vmImage: 'windows-latest'
-
-  ${{if eq(parameters.doCodeSign, 'true')}}:
-    pool:
-      name: Package ES Lab E
-  
   variables:
     solution: '**/*.sln'
     buildPlatform: 'Any CPU'


### PR DESCRIPTION
Package ES pool has huge backlogs. PublishMRT job no longer does any signing, thus no need to use Package ES.