### PR TITLE
[MRTCore] Call GetPackagingOutputs on referenced UWP projects.

### DIFF
--- a/dev/MRTCore/packaging/Microsoft.ApplicationModel.Resources.PriGen.targets
+++ b/dev/MRTCore/packaging/Microsoft.ApplicationModel.Resources.PriGen.targets
@@ -2104,14 +2104,31 @@
                  and '%(ProjectReferenceWithConfiguration.ReferenceOutputAssembly)' == 'true'"
       SkipNonexistentTargets="true"
       ContinueOnError="$(_ContinueOnError)">
-      <Output TaskParameter="TargetOutputs" ItemName="_PackagingOutputsFromOtherProjects"/>
+      <Output TaskParameter="TargetOutputs" ItemName="_PackagingOutputsFromOtherMrtCoreProjects"/>
+    </MSBuild>
+
+    <!-- The referenced project may not be using MRTCore. In that case, GetMrtPackagingOutputs won't be defined. However, if the
+         project is of type UWP, it'll have GetPackagingOutputs defined. So, try calling GetPackagingOutputs. If it does not exist,
+         we simply no-op - see the SkipNonexistentTargets parameter below. -->
+    <MSBuild
+      Projects="@(ProjectReferenceWithConfiguration)"
+      Targets="GetPackagingOutputs"
+      BuildInParallel="$(BuildInParallel)"
+      Properties="%(ProjectReferenceWithConfiguration.SetConfiguration); %(ProjectReferenceWithConfiguration.SetPlatform)"
+      Condition="'@(ProjectReferenceWithConfiguration)' != ''
+                 and '%(ProjectReferenceWithConfiguration.BuildReference)' == 'true'
+                 and '%(ProjectReferenceWithConfiguration.ReferenceOutputAssembly)' == 'true'"
+      SkipNonexistentTargets="true"
+      ContinueOnError="$(_ContinueOnError)">
+      <Output TaskParameter="TargetOutputs" ItemName="_PackagingOutputsFromOtherUwpProjects"/>
     </MSBuild>
 
     <ItemGroup>
       <_PackagingOutputsOutsideLayout Include="@(ProjectPriFile)" />
       <_PackagingOutputsOutsideLayout Include="@(_PackagingOutputsExpanded)" />
       <_PackagingOutputsOutsideLayout Include="@(_GetResolvedSDKReferencesOutput)" />
-      <_PackagingOutputsOutsideLayout Include="@(_PackagingOutputsFromOtherProjects)" />
+      <_PackagingOutputsOutsideLayout Include="@(_PackagingOutputsFromOtherMrtCoreProjects)" />
+      <_PackagingOutputsOutsideLayout Include="@(_PackagingOutputsFromOtherUwpProjects)" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Copy paste of code comment:
The referenced project may not be using MRTCore. In that case, `GetMrtPackagingOutputs` won't be defined. However, if the project is of type UWP, it'll have `GetPackagingOutputs` defined. So, try calling `GetPackagingOutputs`. If it does not exist, we simply no-op - see the `SkipNonexistentTargets` parameter below.

Note: we renamed `GetPackagingOutputs` to `GetMrtPackagingOutputs` in MRTCore because .NET 5 calling `GetPackagingOutputs` resulted in issues. Us calling `GetPackagingOutputs` in a .NET 5 project though should be fine.

How verified:
Resources from the core project of the Adobe app now show up in the top-level resources.pri.