### PR TITLE
Copy the full package target files into the full package

### DIFF
--- a/build/AzurePipelinesTemplates/ProjectReunion-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/ProjectReunion-CreateNugetPackage-Job.yml
@@ -100,7 +100,7 @@ jobs:
     displayName: 'Copy Project Reunion full package targets'
     inputs:
       targetType: inline
-      script: >
+      script: |
       $fullpackagePath = "${{ parameters.fullnupkgdir }}"
       $targetsFilePath = "$(Build.SourcesDirectory)\build\NuSpecs"
       Copy-Item -Path "$targetsFilePath\ProjectReunion-Nuget-Native.targets" -Destination "$fullpackagePath\build\native\Microsoft.ProjectReunion.Foundation.targets"

--- a/build/AzurePipelinesTemplates/ProjectReunion-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/ProjectReunion-CreateNugetPackage-Job.yml
@@ -95,12 +95,16 @@ jobs:
       TargetFolder: '$(Build.ArtifactStagingDirectory)\AppXContents'
       flattenFolders: false
 
-  - powershell: |
+  # Copy the Project Reunion full package specific target files into the full package folder
+  - task: PowerShell@2
+    displayName: 'Copy Project Reunion full package targets'
+    inputs:
+      targetType: inline
+      script: >
       $fullpackagePath = "${{ parameters.fullnupkgdir }}"
       $targetsFilePath = "$(Build.SourcesDirectory)\build\NuSpecs"
       Copy-Item -Path "$targetsFilePath\ProjectReunion-Nuget-Native.targets" -Destination "$fullpackagePath\build\native\Microsoft.ProjectReunion.Foundation.targets"
       Copy-Item -Path "$targetsFilePath\ProjectReunion-Nuget-Common.targets" -Destination "$fullpackagePath\build\Microsoft.ProjectReunion.targets"
-    displayName: 'Copy Project Reunion full package targets'
 
   # debugging - remove or comment out before completing PR      
   - script: |

--- a/build/AzurePipelinesTemplates/ProjectReunion-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/ProjectReunion-CreateNugetPackage-Job.yml
@@ -99,12 +99,12 @@ jobs:
   - task: PowerShell@2
     displayName: 'Copy Project Reunion full package targets'
     inputs:
-      targetType: inline
+      targetType: 'inline'
       script: |
-      $fullpackagePath = "${{ parameters.fullnupkgdir }}"
-      $targetsFilePath = "$(Build.SourcesDirectory)\build\NuSpecs"
-      Copy-Item -Path "$targetsFilePath\ProjectReunion-Nuget-Native.targets" -Destination "$fullpackagePath\build\native\Microsoft.ProjectReunion.Foundation.targets"
-      Copy-Item -Path "$targetsFilePath\ProjectReunion-Nuget-Common.targets" -Destination "$fullpackagePath\build\Microsoft.ProjectReunion.targets"
+        $targetsFilePath = "$(Build.SourcesDirectory)\build\NuSpecs"
+        $fullpackagePath = "${{ parameters.fullnupkgdir }}"
+        Copy-Item -Path "$targetsFilePath\ProjectReunion-Nuget-Native.targets" -Destination "$fullpackagePath\build\native\Microsoft.ProjectReunion.Foundation.targets"
+        Copy-Item -Path "$targetsFilePath\ProjectReunion-Nuget-Common.targets" -Destination "$fullpackagePath\build\Microsoft.ProjectReunion.targets"
 
   # debugging - remove or comment out before completing PR      
   - script: |

--- a/build/AzurePipelinesTemplates/ProjectReunion-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/ProjectReunion-CreateNugetPackage-Job.yml
@@ -95,6 +95,13 @@ jobs:
       TargetFolder: '$(Build.ArtifactStagingDirectory)\AppXContents'
       flattenFolders: false
 
+  - powershell: |
+      $fullpackagePath = "${{ parameters.fullnupkgdir }}"
+      $targetsFilePath = "$(Build.SourcesDirectory)\build\NuSpecs"
+      Copy-Item -Path "$targetsFilePath\ProjectReunion-Nuget-Native.targets" -Destination "$fullpackagePath\build\native\Microsoft.ProjectReunion.Foundation.targets"
+      Copy-Item -Path "$targetsFilePath\ProjectReunion-Nuget-Common.targets" -Destination "$fullpackagePath\build\Microsoft.ProjectReunion.targets"
+    displayName: 'Copy Project Reunion full package targets'
+
   # debugging - remove or comment out before completing PR      
   - script: |
       dir /s $(Build.SourcesDirectory)


### PR DESCRIPTION
This change copies the full package targets into the full package that will be pushed to the internal repo. The main thing needed here is the references to the project reunion winmds in the targets file.