### PR TITLE
Remove the Project Reunion Foundation CopyLocals for binaries

### DIFF
--- a/build/NuSpecs/ProjectReunion-Nuget-Native.targets
+++ b/build/NuSpecs/ProjectReunion-Nuget-Native.targets
@@ -9,7 +9,7 @@
     <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.ProjectReunion.winmd">
       <Implementation>Microsoft.ProjectReunion.dll</Implementation>
     </Reference>
-	  <!--  TODO: Figure out the right long term approach for VS to not pick these up when using them with a framework package. -->
+	  <!--  Figure out the right long term approach for VS to not pick these up when using them with a framework package. -->
     <!-- <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(Native-Platform)\native\Microsoft.ProjectReunion.dll" /> -->
     <!-- <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(Native-Platform)\native\Microsoft.ProjectReunion.pri" /> -->
   </ItemGroup>

--- a/build/NuSpecs/ProjectReunion-Nuget-Native.targets
+++ b/build/NuSpecs/ProjectReunion-Nuget-Native.targets
@@ -9,7 +9,7 @@
     <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.ProjectReunion.winmd">
       <Implementation>Microsoft.ProjectReunion.dll</Implementation>
     </Reference>
-	  <!--  Figure out the right long term approach for VS to not pick these up when using them with a framework package. -->
+    <!--  Figure out the right long term approach for VS to not pick these up when using them with a framework package. -->
     <!-- <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(Native-Platform)\native\Microsoft.ProjectReunion.dll" /> -->
     <!-- <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(Native-Platform)\native\Microsoft.ProjectReunion.pri" /> -->
   </ItemGroup>

--- a/build/NuSpecs/ProjectReunion-Nuget-Native.targets
+++ b/build/NuSpecs/ProjectReunion-Nuget-Native.targets
@@ -9,7 +9,8 @@
     <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.ProjectReunion.winmd">
       <Implementation>Microsoft.ProjectReunion.dll</Implementation>
     </Reference>
-    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(Native-Platform)\native\Microsoft.ProjectReunion.dll" />
-    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(Native-Platform)\native\Microsoft.ProjectReunion.pri" />
+	  <!--  TODO: Figure out the right long term approach for VS to not pick these up when using them with a framework package. -->
+    <!-- <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(Native-Platform)\native\Microsoft.ProjectReunion.dll" /> -->
+    <!-- <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(Native-Platform)\native\Microsoft.ProjectReunion.pri" /> -->
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This is a change to temporarily remove the CopyLocals for the Project Reunion Foundation binaries. This package is only ever used as a framework package and so these do not need to be here for the initial bring up of the pipelines. In the future we will have a more robust programmatic solution.