### PR TITLE
Add <disabledPackageSources>

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,5 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
+
   <packageSources>
     <clear />
 
@@ -12,8 +16,4 @@
     <add key="MUX-Dependencies" value="https://pkgs.dev.azure.com/ms/microsoft-ui-xaml/_packaging/MUX-Dependencies/nuget/v3/index.json" />
     <add key="WindowsES-External" value="https://microsoft.pkgs.visualstudio.com/_packaging/WindowsES-External/nuget/v3/index.json" />
   </packageSources>
-
-  <disabledPackageSources>
-    <clear />
-  </disabledPackageSources>
 </configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -12,4 +12,8 @@
     <add key="MUX-Dependencies" value="https://pkgs.dev.azure.com/ms/microsoft-ui-xaml/_packaging/MUX-Dependencies/nuget/v3/index.json" />
     <add key="WindowsES-External" value="https://microsoft.pkgs.visualstudio.com/_packaging/WindowsES-External/nuget/v3/index.json" />
   </packageSources>
+
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
 </configuration>


### PR DESCRIPTION
Add `<disabledPackageSources>`

Per latest guidance "How to Securely Configure Package Source Files" `nuget.config` should have `<packageSources>` and `<disabledPackageSources>` and start both with `<clear />`. Current `nuget.config` had no `<disabledPackageSources>`.