### PR TITLE
Quality of Life changes on ReleaseSigning controls

### DIFF
--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -1,9 +1,13 @@
 name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 variables:
   minimumExpectedTestsExecutedCount: 35  # Sanity check for minimum expected tests to be reported
-  
-jobs:
 
+parameters:
+  - name: "ReleaseSign"
+    type: boolean
+    default: False
+
+jobs:
 - job: Build
   # Skip the build job if we are reusing the output of a previous build.
   # useBuildOutputFromBuildId variable is set on the Pipeline at Queue time.
@@ -189,7 +193,7 @@ jobs:
       MaxConcurrency: '50'
       MaxRetryAttempts: '5'
     condition: 
-      eq(variables['ReleaseSign'], true)
+      eq(${{ parameters.ReleaseSign }}, true)
 
   - task: EsrpCodeSigning@1
     inputs:
@@ -233,7 +237,7 @@ jobs:
       MaxConcurrency: '50'
       MaxRetryAttempts: '5'
     condition: 
-      ne(variables['ReleaseSign'], true)
+      eq(${{ parameters.ReleaseSign }}, false)
 
   # Re-publish signed artifacts to the fullnuget artifact.
   - task: PublishBuildArtifacts@1

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -3,7 +3,7 @@ variables:
   minimumExpectedTestsExecutedCount: 35  # Sanity check for minimum expected tests to be reported
 
 parameters:
-  - name: "ReleaseSign"
+  - name: "ReleaseSigning"
     type: boolean
     default: False
 
@@ -193,7 +193,7 @@ jobs:
       MaxConcurrency: '50'
       MaxRetryAttempts: '5'
     condition: 
-      eq(${{ parameters.ReleaseSign }}, true)
+      eq(${{ parameters.ReleaseSigning }}, true)
 
   - task: EsrpCodeSigning@1
     inputs:
@@ -237,7 +237,7 @@ jobs:
       MaxConcurrency: '50'
       MaxRetryAttempts: '5'
     condition: 
-      eq(${{ parameters.ReleaseSign }}, false)
+      eq(${{ parameters.ReleaseSigning }}, false)
 
   # Re-publish signed artifacts to the fullnuget artifact.
   - task: PublishBuildArtifacts@1


### PR DESCRIPTION
This adds a checkbox on the pipeline run widget that you can check if you want to do ReleaseSigning. It's easier than typing out "true" to a variable. Just quality of life changes. 