### PR TITLE
Update MRTCore.WinRT.props hintpath value to point to the WinMD

### DIFF
--- a/dev/MRTCore/packaging/native/Microsoft.ApplicationModel.Resources.WinRt.props
+++ b/dev/MRTCore/packaging/native/Microsoft.ApplicationModel.Resources.WinRt.props
@@ -15,7 +15,7 @@
   <!-- OutputType Exe corresponds to C++. -->
   <ItemGroup Condition="'$(OutputType)' == 'Exe'">
     <Reference Include="Microsoft.ApplicationModel.Resources.winmd">
-      <HintPath>$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.ApplicationModel.Resources.winmd</HintPath>
+      <HintPath>$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.ApplicationModel.Resources\Microsoft.ApplicationModel.Resources.winmd</HintPath>
       <Implementation>$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(_MrtCoreRuntimeIdentifier)\native\Microsoft.ApplicationModel.Resources.dll</Implementation>
       <IsWinMDFile>true</IsWinMDFile>
     </Reference>


### PR DESCRIPTION
Description:
The hintpath in the Microsoft.ApplicationModel.Resources.WinRT.props file did not match the path that the WinMD's location in the metapackage.  This change fixes that.