### PR TITLE
Removing stale status badge from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 ﻿# Project Reunion
-  
-![Build CI Master](https://github.com/microsoft/ProjectReunion/workflows/Build%20CI%20Master/badge.svg)
+
 [![Feature Proposals](https://img.shields.io/github/issues/microsoft/projectreunion/feature%20proposal)](https://github.com/microsoft/ProjectReunion/issues?q=is%3Aissue+is%3Aopen+label%3A%22feature+proposal%22)
 [![Bugs](https://img.shields.io/github/issues/microsoft/projectreunion/bug)](https://github.com/microsoft/ProjectReunion/issues?q=is%3Aissue+is%3Aopen+label%3Abug)
 


### PR DESCRIPTION
This change removes a stale status badge for a github workflow that's no longer in use. The project is currently being built using azure pipelines in a private repository. In the future I'll investigate how to provide better live build status, but I'm removing the old badge so that people don't get the wrong idea and thing the project is sitting unattended in a broken state.
