### PR TITLE
Stop building ARM for ProjectReunion Foundation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,8 +32,5 @@ jobs:
     - name: build x64
       run: msbuild /m /p:Configuration=Release,Platform=x64 ProjectReunion.sln
 
-    - name: build ARM
-      run: msbuild /m /p:Configuration=Release,Platform=ARM ProjectReunion.sln
-
     - name: build ARM64
       run: msbuild /m /p:Configuration=Release,Platform=ARM64 ProjectReunion.sln

--- a/build/AzurePipelinesTemplates/ProjectReunion-NugetReleaseTest-Job.yml
+++ b/build/AzurePipelinesTemplates/ProjectReunion-NugetReleaseTest-Job.yml
@@ -22,9 +22,6 @@ parameters:
     Release_x64:
       buildPlatform: 'x64'
       buildConfiguration: 'Release'
-    Release_arm:
-      buildPlatform: 'arm'
-      buildConfiguration: 'Release'
 
 jobs:
 - job: ${{ parameters.buildJobName }}

--- a/build/AzurePipelinesTemplates/ProjectReunion-WACKTests-Job.yml
+++ b/build/AzurePipelinesTemplates/ProjectReunion-WACKTests-Job.yml
@@ -9,9 +9,7 @@ parameters:
     Release_x64:
       buildPlatform: 'x64'
       buildConfiguration: 'Release'
-    Release_Arm:
-      buildPlatform: 'arm'
-      buildConfiguration: 'Release'
+
 jobs:
 - job: ${{ parameters.name }}
   dependsOn: ${{ parameters.dependsOn }}

--- a/build/NuSpecs/build-nupkg.ps1
+++ b/build/NuSpecs/build-nupkg.ps1
@@ -112,8 +112,6 @@ Copy-IntoNewDirectory -IfExists $BuildOutput\$BuildFlavor\x86\Microsoft.ProjectR
 Copy-IntoNewDirectory -IfExists $BuildOutput\$BuildFlavor\x86\Microsoft.ProjectReunion\Microsoft.ProjectReunion.pri "$runtimesDir\win10-x86\native"
 Copy-IntoNewDirectory -IfExists $BuildOutput\$BuildFlavor\x64\Microsoft.ProjectReunion\Microsoft.ProjectReunion.dll "$runtimesDir\win10-x64\native"
 Copy-IntoNewDirectory -IfExists $BuildOutput\$BuildFlavor\x64\Microsoft.ProjectReunion\Microsoft.ProjectReunion.pri "$runtimesDir\win10-x64\native"
-Copy-IntoNewDirectory -IfExists $BuildOutput\$BuildFlavor\arm\Microsoft.ProjectReunion\Microsoft.ProjectReunion.dll "$runtimesDir\win10-arm\native"
-Copy-IntoNewDirectory -IfExists $BuildOutput\$BuildFlavor\arm\Microsoft.ProjectReunion\Microsoft.ProjectReunion.pri "$runtimesDir\win10-arm\native"
 Copy-IntoNewDirectory -IfExists $BuildOutput\$BuildFlavor\arm64\Microsoft.ProjectReunion\Microsoft.ProjectReunion.dll "$runtimesDir\win10-arm64\native"
 Copy-IntoNewDirectory -IfExists $BuildOutput\$BuildFlavor\arm64\Microsoft.ProjectReunion\Microsoft.ProjectReunion.pri "$runtimesDir\win10-arm64\native"
 
@@ -163,12 +161,10 @@ if(-not $SkipFrameworkPackage)
 
     Copy-IntoNewDirectory -IfExists $BuildOutput\$BuildFlavor\x86\FrameworkPackage\Microsoft.ProjectReunion.*.appx "$toolsDir\AppX\x86\Release"
     Copy-IntoNewDirectory -IfExists $BuildOutput\$BuildFlavor\x64\FrameworkPackage\Microsoft.ProjectReunion.*.appx "$toolsDir\AppX\x64\Release"
-    Copy-IntoNewDirectory -IfExists $BuildOutput\$BuildFlavor\arm\FrameworkPackage\Microsoft.ProjectReunion.*.appx "$toolsDir\AppX\arm\Release"
     Copy-IntoNewDirectory -IfExists $BuildOutput\$BuildFlavor\arm64\FrameworkPackage\Microsoft.ProjectReunion.*.appx "$toolsDir\AppX\arm64\Release"
     # Currently we don't have a separate Debug package that we want to ship to customers
     #Copy-IntoNewDirectory -IfExists $BuildOutput\debug\x86\FrameworkPackage\Microsoft.ProjectReunion.Debug.*.appx "$toolsDir\AppX\x86\Debug"
     #Copy-IntoNewDirectory -IfExists $BuildOutput\debug\x64\FrameworkPackage\Microsoft.ProjectReunion.Debug.*.appx "$toolsDir\AppX\x64\Debug"
-    #Copy-IntoNewDirectory -IfExists $BuildOutput\debug\arm\FrameworkPackage\Microsoft.ProjectReunion.Debug.*.appx "$toolsDir\AppX\arm\Debug"
     #Copy-IntoNewDirectory -IfExists $BuildOutput\debug\arm64\FrameworkPackage\Microsoft.ProjectReunion.Debug.*.appx "$toolsDir\AppX\arm64\Debug"
 
     $NugetCmdLine = "$nugetExe pack ProjectReunionFrameworkPackage.nuspec $NugetArgs -version $version"

--- a/build/ProjectReunion-BuildFoundation.yml
+++ b/build/ProjectReunion-BuildFoundation.yml
@@ -29,10 +29,6 @@ jobs:
         buildConfiguration: 'Release'
         normalizedConfiguration: 'fre'
         PGOBuildMode: 'Optimize'
-      Release_Arm:
-        buildPlatform: 'arm'
-        buildConfiguration: 'Release'
-        normalizedConfiguration: 'fre'
       Release_Arm64:
         buildPlatform: 'arm64'
         buildConfiguration: 'Release'

--- a/build/ProjectReunion-CI.yml
+++ b/build/ProjectReunion-CI.yml
@@ -23,9 +23,6 @@ jobs:
         buildPlatform: 'x64'
         buildConfiguration: 'Release'
         PGOBuildMode: 'Optimize'
-      Release_Arm:
-        buildPlatform: 'arm'
-        buildConfiguration: 'Release'
       Release_Arm64:
         buildPlatform: 'arm64'
         buildConfiguration: 'Release'

--- a/dev/MRTCore/azure-pipelines.yml
+++ b/dev/MRTCore/azure-pipelines.yml
@@ -19,9 +19,6 @@ jobs:
       Release_x64:
         buildPlatform: 'x64'
         buildConfiguration: 'Release'
-      Release_Arm:
-        buildPlatform: 'ARM'
-        buildConfiguration: 'Release'
       Release_Arm64:
         buildPlatform: 'ARM64'
         buildConfiguration: 'Release'
@@ -312,18 +309,6 @@ jobs:
       flattenFolders: true
 
   - task: CopyFiles@2
-    displayName: 'copy ARM'
-    inputs:
-      SourceFolder: '$(Build.ArtifactStagingDirectory)\mrt_raw\mrtcore_binaries\lib\ARM'
-      Contents: |
-        mrm.pdb
-        Microsoft.ApplicationModel.Resources.pdb
-        mrm.dll
-        Microsoft.ApplicationModel.Resources.dll
-      TargetFolder: '$(Build.ArtifactStagingDirectory)\fullnuget\runtimes\win10-arm\native'
-      flattenFolders: true
-
-  - task: CopyFiles@2
     displayName: 'copy ARM64'
     inputs:
       SourceFolder: '$(Build.ArtifactStagingDirectory)\mrt_raw\mrtcore_binaries\lib\ARM64'
@@ -351,15 +336,6 @@ jobs:
       Contents: |
         mrm.lib
       TargetFolder: '$(Build.ArtifactStagingDirectory)\fullnuget\lib\win10-x64'
-      flattenFolders: true
-
-  - task: CopyFiles@2
-    displayName: 'copy import lib ARM'
-    inputs:
-      SourceFolder: '$(Build.ArtifactStagingDirectory)\mrt_raw\mrtcore_binaries\lib\ARM'
-      Contents: |
-        mrm.lib
-      TargetFolder: '$(Build.ArtifactStagingDirectory)\fullnuget\lib\win10-arm'
       flattenFolders: true
 
   - task: CopyFiles@2


### PR DESCRIPTION
There was a decision to not support ARM and some of the packages we are using will not have an ARM version. 

Don't want to do have to do something like
#ifndef arm32
in our code. 