### PR TITLE
add appx manifest to foundation transport package

### DIFF
--- a/build/AzurePipelinesTemplates/ProjectReunion-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/ProjectReunion-CreateNugetPackage-Job.yml
@@ -47,9 +47,9 @@ jobs:
         LICENSE
       TargetFolder: '${{ parameters.fullnupkgdir }}'
 
-  # Copy the Project Reunion full package specific target files into the full package folder
+  # Copy the Project Reunion full package specific target files and AppxManifest into the full package folder
   - task: PowerShell@2
-    displayName: 'Copy Project Reunion full package targets'
+    displayName: 'Copy Project Reunion full package assets'
     inputs:
       targetType: 'inline'
       script: |
@@ -57,8 +57,9 @@ jobs:
         $fullpackagePath = "${{ parameters.fullnupkgdir }}"
         Copy-Item -Path "$targetsFilePath\ProjectReunion-Nuget-Native.targets" -Destination "$fullpackagePath\build\native\Microsoft.ProjectReunion.Foundation.targets"
         Copy-Item -Path "$targetsFilePath\Microsoft.ProjectReunion.Foundation.props" -Destination "$fullpackagePath\build\native\Microsoft.ProjectReunion.Foundation.props"
+  # Include the AppxManifest in the ProjectReunion.Foundation.TransportPackage
         Copy-Item -Path "$targetsFilePath\AppxManifest.xml" -Destination "$fullpackagePath\AppxManifest.xml"
-        
+
   # debugging - remove or comment out before completing PR      
   # - script: |
   #     dir /s $(Build.SourcesDirectory)

--- a/build/AzurePipelinesTemplates/ProjectReunion-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/ProjectReunion-CreateNugetPackage-Job.yml
@@ -57,7 +57,7 @@ jobs:
         $fullpackagePath = "${{ parameters.fullnupkgdir }}"
         Copy-Item -Path "$targetsFilePath\ProjectReunion-Nuget-Native.targets" -Destination "$fullpackagePath\build\native\Microsoft.ProjectReunion.Foundation.targets"
         Copy-Item -Path "$targetsFilePath\Microsoft.ProjectReunion.Foundation.props" -Destination "$fullpackagePath\build\native\Microsoft.ProjectReunion.Foundation.props"
-  # Include the AppxManifest in the ProjectReunion.Foundation.TransportPackage
+
         Copy-Item -Path "$targetsFilePath\AppxManifest.xml" -Destination "$fullpackagePath\AppxManifest.xml"
 
   # debugging - remove or comment out before completing PR      

--- a/build/AzurePipelinesTemplates/ProjectReunion-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/ProjectReunion-CreateNugetPackage-Job.yml
@@ -57,7 +57,8 @@ jobs:
         $fullpackagePath = "${{ parameters.fullnupkgdir }}"
         Copy-Item -Path "$targetsFilePath\ProjectReunion-Nuget-Native.targets" -Destination "$fullpackagePath\build\native\Microsoft.ProjectReunion.Foundation.targets"
         Copy-Item -Path "$targetsFilePath\Microsoft.ProjectReunion.Foundation.props" -Destination "$fullpackagePath\build\native\Microsoft.ProjectReunion.Foundation.props"
-
+        Copy-Item -Path "$targetsFilePath\AppxManifest.xml" -Destination "$fullpackagePath\AppxManifest.xml"
+        
   # debugging - remove or comment out before completing PR      
   # - script: |
   #     dir /s $(Build.SourcesDirectory)

--- a/build/NuSpecs/AppxManifest.xml
+++ b/build/NuSpecs/AppxManifest.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:build="http://schemas.microsoft.com/developer/appx/2015/build" IgnorableNamespaces="uap build">
+  <Identity Name="Microsoft.ProjectReunion.0.5" ProcessorArchitecture="x64" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="0.52102.3000.0" />
+  <Properties>
+    <Framework>true</Framework>
+    <DisplayName>Microsoft.ProjectReunion.0.5</DisplayName>
+    <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
+    <Description>Microsoft Project Reunion Framework</Description>
+    <Logo>logo.png</Logo>
+  </Properties>
+  <Resources>
+    <Resource Language="en-US" />
+  </Resources>
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.18362.0" />
+  </Dependencies>
+  <Extensions>
+    <Extension Category="windows.activatableClass.inProcessServer">
+      <InProcessServer>
+        <Path>Microsoft.ApplicationModel.Resources.dll</Path>
+          <ActivatableClass ActivatableClassId="Microsoft.ApplicationModel.Resources.KnownResourceQualifierName" ThreadingModel="both" />
+          <ActivatableClass ActivatableClassId="Microsoft.ApplicationModel.Resources.ResourceCandidate" ThreadingModel="both" />
+          <ActivatableClass ActivatableClassId="Microsoft.ApplicationModel.Resources.ResourceLoader" ThreadingModel="both" />
+          <ActivatableClass ActivatableClassId="Microsoft.ApplicationModel.Resources.ResourceManager" ThreadingModel="both" />
+      </InProcessServer>
+    </Extension>  
+    <Extension Category="windows.activatableClass.inProcessServer">
+      <InProcessServer>
+        <Path>Microsoft.ProjectReunion.dll</Path>
+          <ActivatableClass ActivatableClassId="Microsoft.ProjectReunion.ActivationRegistrationManager" ThreadingModel="both" />
+          <ActivatableClass ActivatableClassId="Microsoft.ProjectReunion.AppLifecycle" ThreadingModel="both" />
+      </InProcessServer>
+    </Extension>
+  </Extensions>
+</Package>


### PR DESCRIPTION
Adding an Appx Manifest that was previously being hardcoded into the PR Framework Package. Now it will be obtained from the Project Reunion Foundation Transport package. 