### PR TITLE
Update MRTCore to use the newest UDK

### DIFF
--- a/dev/MRTCore/mrt/Microsoft.ApplicationModel.Resources/src/Helper.cpp
+++ b/dev/MRTCore/mrt/Microsoft.ApplicationModel.Resources/src/Helper.cpp
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #include "pch.h"
-#include "frameworkudk\mrtcore.h"
+#include "frameworkudk\ResourceManager.h"
 
 bool IsResourceNotFound(HRESULT hr)
 {
@@ -38,7 +38,7 @@ HRESULT GetDefaultPriFileForCurentModule(winrt::hstring& filePath)
 HRESULT GetDefaultPriFileForCurrentPackage(winrt::hstring& filePath)
 {
     wchar_t* resourceFile = nullptr;
-    HRESULT hr = MrtCore_GetDefaultResourcePathForPackageFullName(nullptr, &resourceFile);
+    HRESULT hr = ResourceManager_GetDefaultResourcePathForPackageFullName(nullptr, &resourceFile);
     if (FAILED(hr))
     {
         return hr;

--- a/dev/MRTCore/mrt/Microsoft.ApplicationModel.Resources/src/Microsoft.ApplicationModel.Resources.vcxproj
+++ b/dev/MRTCore/mrt/Microsoft.ApplicationModel.Resources/src/Microsoft.ApplicationModel.Resources.vcxproj
@@ -190,7 +190,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="..\..\packages\Microsoft.FrameworkUdk.$(Udk-Arch)fre.10.0.21315.1001-210214-1000.rs-wdx-dxp-ixp1\build\native\Microsoft.FrameworkUdk.$(Udk-Arch)fre.targets" Condition="Exists('..\..\packages\Microsoft.FrameworkUdk.$(Udk-Arch)fre.10.0.21315.1001-210214-1000.rs-wdx-dxp-ixp1\build\native\Microsoft.FrameworkUdk.$(Udk-Arch)fre.targets')" />
+    <Import Project="..\..\packages\Microsoft.FrameworkUdk.$(Udk-Arch)fre.10.0.21324.1000-210225-1000.rs-wdx-dxp-ixp1\build\native\Microsoft.FrameworkUdk.$(Udk-Arch)fre.targets" Condition="Exists('..\..\packages\Microsoft.FrameworkUdk.$(Udk-Arch)fre.10.0.21324.1000-210225-1000.rs-wdx-dxp-ixp1\build\native\Microsoft.FrameworkUdk.$(Udk-Arch)fre.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -198,6 +198,6 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.FrameworkUdk.$(Udk-Arch)fre.10.0.21315.1001-210214-1000.rs-wdx-dxp-ixp1\build\native\Microsoft.FrameworkUdk.$(Udk-Arch)fre.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.FrameworkUdk.$(Udk-Arch)fre.10.0.21315.1001-210214-1000.rs-wdx-dxp-ixp1\build\native\Microsoft.FrameworkUdk.$(Udk-Arch)fre.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.FrameworkUdk.$(Udk-Arch)fre.10.0.21324.1000-210225-1000.rs-wdx-dxp-ixp1\build\native\Microsoft.FrameworkUdk.$(Udk-Arch)fre.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.FrameworkUdk.$(Udk-Arch)fre.10.0.21324.1000-210225-1000.rs-wdx-dxp-ixp1\build\native\Microsoft.FrameworkUdk.$(Udk-Arch)fre.targets'))" />
   </Target>
 </Project>

--- a/dev/MRTCore/mrt/Microsoft.ApplicationModel.Resources/src/packages.config
+++ b/dev/MRTCore/mrt/Microsoft.ApplicationModel.Resources/src/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.FrameworkUdk.amd64fre" version="10.0.21315.1001-210214-1000.rs-wdx-dxp-ixp1" targetFramework="native" />
-  <package id="Microsoft.FrameworkUdk.arm64fre" version="10.0.21315.1001-210214-1000.rs-wdx-dxp-ixp1" targetFramework="native" />
-  <package id="Microsoft.FrameworkUdk.x86fre" version="10.0.21315.1001-210214-1000.rs-wdx-dxp-ixp1" targetFramework="native" />
+  <package id="Microsoft.FrameworkUdk.amd64fre" version="10.0.21324.1000-210225-1000.rs-wdx-dxp-ixp1" targetFramework="native" />
+  <package id="Microsoft.FrameworkUdk.arm64fre" version="10.0.21324.1000-210225-1000.rs-wdx-dxp-ixp1" targetFramework="native" />
+  <package id="Microsoft.FrameworkUdk.x86fre" version="10.0.21324.1000-210225-1000.rs-wdx-dxp-ixp1" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200729.8" targetFramework="native" />
 </packages>


### PR DESCRIPTION
Update MRTCore to use the newest UDK
Change the caller because the header and the api name changed