### PR TITLE
Add note about catching exceptions in C++

### DIFF
--- a/docs/Coding-Guidelines.md
+++ b/docs/Coding-Guidelines.md
@@ -19,8 +19,8 @@ Use the following snippet to catch exceptions and retrieve their HRESULT:
 ```c++
 catch (...)
 {
-    auto e{ hresult_error(to_hresult(), take_ownership_from_abi) };
-    ...e.code() contains the HRESULT...
+    auto e{ winrt::hresult_error(winrt::to_hresult(), winrt::take_ownership_from_abi) };
+    ...e.code() contains the WinRT exception or best-guess conversion from a C++ exception...
 }
 ```
 

--- a/docs/Coding-Guidelines.md
+++ b/docs/Coding-Guidelines.md
@@ -16,7 +16,7 @@ Don't just catch `winrt::hresult_error` or other variations as that doesn't catc
 
 Use the following snippet to catch exceptions and retrieve their HRESULT:
 
-```
+```c++
 catch (...)
 {
     auto e{ hresult_error(to_hresult(), take_ownership_from_abi) };

--- a/docs/Coding-Guidelines.md
+++ b/docs/Coding-Guidelines.md
@@ -12,7 +12,7 @@ rather than creating your own.
 
 ##### Catching Exceptions and HRESULT
 
-Don't just catch winrt::hresult_error or other variations as that doesn't catch std::bad_alloc.
+Don't just catch `winrt::hresult_error` or other variations as that doesn't catch `std::bad_alloc`.
 
 Use the following snippet to catch exceptions and retrieve their HRESULT:
 

--- a/docs/Coding-Guidelines.md
+++ b/docs/Coding-Guidelines.md
@@ -4,17 +4,31 @@ Project Reunion prefers using industry-standard coding styles, guidelines, and p
 
 #### C++
 
-Project Reunion implementations prefer C++ and C++/WinRT implementations.   New code must adhere to the **cppcoreguidelines** at 
+Project Reunion implementations prefer C++ and C++/WinRT implementations.   New code must adhere to the **cppcoreguidelines** at
 https://github.com/isocpp/CppCoreGuidelines and be /W4 clean (for Visual C++.)
 
-Prefer existing std:: and gsl:: types, but use **wil** (https://github.com/Microsoft/wil) types for Windows-specific helpers and lifecycle management 
+Prefer existing std:: and gsl:: types, but use **wil** (https://github.com/Microsoft/wil) types for Windows-specific helpers and lifecycle management
 rather than creating your own.
+
+##### Catching Exceptions and HRESULT
+
+Don't just catch winrt::hresult_error or other variations as that doesn't catch std::bad_alloc.
+
+Use the following snippet to catch exceptions and retrieve their HRESULT:
+
+```
+catch (...)
+{
+    auto e{ hresult_error(to_hresult(), take_ownership_from_abi) };
+    ...e.code() contains the HRESULT...
+}
+```
 
 #### Markdown
 
-**GUIDELINE:** The preferred line length limit is ~100 characters. GitHub formats lines regardless of individual length but GitHub diff is line oriented. 
+**GUIDELINE:** The preferred line length limit is ~100 characters. GitHub formats lines regardless of individual length but GitHub diff is line oriented.
 Keeping lines within the preferred limit makes changes easier to review.
 
 #### Other Languages
 
-If new languages become common, we will describe the coding guidelines for such languages here.  
+If new languages become common, we will describe the coding guidelines for such languages here.


### PR DESCRIPTION
Added best practice about catching C++ exceptions and HRESULTS per @kennykerr from [this thread](https://github.com/microsoft/ProjectReunion/pull/508#discussion_r586430665)