### PR TITLE
Revert naming of win32 apps' PRI to the project name.

### DIFF
--- a/dev/MRTCore/packaging/Microsoft.ApplicationModel.Resources.PriGen.targets
+++ b/dev/MRTCore/packaging/Microsoft.ApplicationModel.Resources.PriGen.targets
@@ -205,8 +205,6 @@
     <PriInitialPath Condition="'$(PrependPriInitialPath)' == 'true' and '$(AppxPackage)' == 'true' and '$(PriInitialPath)' == ''"></PriInitialPath>
     <PriInitialPath Condition="'$(PrependPriInitialPath)' == 'true' and '$(AppxPackage)' != 'true' and '$(PriInitialPath)' == ''">$(TargetName)</PriInitialPath>
     <ProjectPriFileName Condition="'$(AppxPackage)' == 'true' and '$(ProjectPriFileName)' == ''">resources.pri</ProjectPriFileName>
-    <!-- An empty '$(ApplicationType)' and '$(WindowsAppContainer)' being false corresponds to a C++, Win32 app. -->
-    <ProjectPriFileName Condition="'$(ApplicationType)' == '' and '$(WindowsAppContainer)' == 'false' and '$(ProjectPriFileName)' == ''">resources.pri</ProjectPriFileName>
     <ProjectPriFileName Condition="'$(AppxPackage)' != 'true' and '$(ProjectPriFileName)' == '' and '$(PriInitialPath)' == ''">$(TargetName).pri</ProjectPriFileName>
     <ProjectPriFileName Condition="'$(AppxPackage)' != 'true' and '$(ProjectPriFileName)' == '' and '$(PriInitialPath)' != ''">$(PriInitialPath).pri</ProjectPriFileName>
     <ProjectPriFullPath Condition="'$(ProjectPriFullPath)' == ''">$(TargetDir)$(AppxPackageArtifactsDir)$(ProjectPriFileName)</ProjectPriFullPath>


### PR DESCRIPTION
Packaged win32 app's resources.pri didn't merge the PRI of the win32 app because that PRI was also called resources.pri.

The name of PRIs generated in win32 projects was recently changed to resources.pri:

[Changes to generate a Microsoft.ProjectReunion.Foundation NuGet package that supports MRTCore on win32. by rohanp-msft · Pull Request #394 · microsoft/ProjectReunion (github.com)](https://github.com/microsoft/ProjectReunion/pull/394/files)

Microsoft.ApplicationModel.Resources.PriGen.targets:
```
<!-- An empty '$(ApplicationType)' and '$(WindowsAppContainer)' being false corresponds to a C++, Win32 app. -->
<ProjectPriFileName Condition="'$(ApplicationType)' == '' and '$(WindowsAppContainer)' == 'false' and '$(ProjectPriFileName)' == ''">resources.pri</ProjectPriFileName>
```

**How verified**
When that mod is removed, the PRI file is named after the project, and the merge happens as expected.