### PR TITLE
address build/restore issues causing vsix pipeline failures

### DIFF
--- a/dev/VSIX/Directory.Build.props
+++ b/dev/VSIX/Directory.Build.props
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
     <!-- Provide default nuget feed (Reunion internal) and package versions for developer builds -->
     <PropertyGroup>
@@ -14,7 +14,10 @@
     </PropertyGroup>
 
     <PropertyGroup>
+        <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
+        <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
         <VSIXBuild>true</VSIXBuild>
+        <RuntimeIdentifiers>win</RuntimeIdentifiers>
         
         <!--PackageReference.GeneratePathProperty does not support NUGET_PACKAGES env var...-->
         <NuGetPackageRoot Condition="'$(NuGetPackageRoot)'==''">$(NUGET_PACKAGES)</NuGetPackageRoot>
@@ -24,9 +27,6 @@
         <PkgMicrosoft_ProjectReunion_Foundation Condition="'$(PkgMicrosoft_ProjectReunion_Foundation)'==''">$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)', 'Microsoft.ProjectReunion.Foundation', '$(ReunionFoundationVersion)'))</PkgMicrosoft_ProjectReunion_Foundation>
         <PkgMicrosoft_ProjectReunion_DWrite Condition="'$(PkgMicrosoft_ProjectReunion_DWrite)'==''">$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)', 'Microsoft.ProjectReunion.DWrite', '$(ReunionDWriteVersion)'))</PkgMicrosoft_ProjectReunion_DWrite>
         <PkgMicrosoft_ProjectReunion_WinUI Condition="'$(PkgMicrosoft_ProjectReunion_WinUI)'==''">$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)', 'Microsoft.ProjectReunion.WinUI', '$(ReunionWinUIVersion)'))</PkgMicrosoft_ProjectReunion_WinUI>
-
-        <!-- TODO: determine why VSToolsPath is inconsistently defined -->
-        <VSToolsPath Condition="'$(VSToolsPath)'==''">$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)', 'microsoft.vssdk.buildtools\16.8.1017\tools'))</VSToolsPath>
 
         <BuildOutput Condition="'$(BuildOutput)' == ''">$(SolutionDir)BuildOutput\</BuildOutput>
         <BuildOutputRoot>$(BuildOutput)obj\$(Platform)$(Configuration)\</BuildOutputRoot>

--- a/dev/VSIX/Extension/ProjectReunion.Extension.csproj
+++ b/dev/VSIX/Extension/ProjectReunion.Extension.csproj
@@ -30,7 +30,6 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="index.html" />
     <Content Include="LICENSE">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>


### PR DESCRIPTION
Main project file would occasionally fail to restore, VsToolsPath would occasionally not be set, causing VSIX targets to not execute.  Fix was to add fallback, as template project files do.

Template project files would fail to build, requiring 'win' RuntimeIdentifier.  Fix for this was to add it to directory.build.props, and not the template projects, as that breaks template instantation.