### PR TITLE
Cherry-Pick: create VSIX pipeline fixes (#537)

### DIFF
--- a/build/ProjectReunion-Create-VSIX.yml
+++ b/build/ProjectReunion-Create-VSIX.yml
@@ -17,13 +17,13 @@ parameters:
 
 jobs:
 
-- job: CreatingVsix
+- job: CreateVSIX
   pool:
     vmImage: 'windows-2019'
 
   variables:
     ${{if eq(parameters.releaseBuild, True) }}:
-      VSIXBuildArgs: '/p:"RestoreSources=https://api.nuget.org/v3/index.json;https://pkgs.dev.azure.com/microsoft/ProjectReunion/_packaging/Project.Reunion.Internal.ReleaseSigned/nuget/v3/index.json"'
+      VSIXBuildArgs: '/p:"RestoreSources=https://pkgs.dev.azure.com/microsoft/ProjectReunion/_packaging/Project.Reunion.Internal.ReleaseSigned/nuget/v3/index.json"'
     ${{if eq(parameters.releaseBuild, False) }}:
       VSIXBuildArgs: ''
       

--- a/build/ProjectReunion-Create-VSIX.yml
+++ b/build/ProjectReunion-Create-VSIX.yml
@@ -32,13 +32,6 @@ jobs:
     inputs:
       nuGetServiceConnections: Internal-ReleaseSigned
 
-  # NuGetCommand@2 
-  - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
-    displayName: 'NuGet restore'
-    inputs:
-      command: 'custom'
-      arguments: 'restore dev\VSIX\packages.config -PackagesDirectory $(UserProfile)\.nuget\packages'
-
   - task: VSBuild@1
     displayName: 'Restore ProjectReunion.Extension.sln'
     inputs:
@@ -53,7 +46,7 @@ jobs:
       solution: dev\VSIX\ProjectReunion.Extension.sln
       platform: 'Any CPU'
       configuration: '$(buildConfiguration)'
-      msBuildArgs: '/p:VSToolsPath="$(UserProfile)\.nuget\packages\microsoft.vssdk.buildtools\16.9.1050\tools" /p:ReunionVersion="${{ parameters.ReunionVersion }}" /p:ReunionFoundationVersion="${{ parameters.ReunionFoundationVersion }}" /p:ReunionDWriteVersion="${{ parameters.ReunionDWriteVersion }}" /p:ReunionWinUIVersion="${{ parameters.ReunionWinUIVersion }}" ${{ variables.VSIXBuildArgs }}'
+      msBuildArgs: '/p:ReunionVersion="${{ parameters.ReunionVersion }}" /p:ReunionFoundationVersion="${{ parameters.ReunionFoundationVersion }}" /p:ReunionDWriteVersion="${{ parameters.ReunionDWriteVersion }}" /p:ReunionWinUIVersion="${{ parameters.ReunionWinUIVersion }}" ${{ variables.VSIXBuildArgs }}'
 
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Governance Detection'

--- a/dev/VSIX/Directory.Build.props
+++ b/dev/VSIX/Directory.Build.props
@@ -4,7 +4,6 @@
     <!-- Provide default nuget feed (Reunion internal) and package versions for developer builds -->
     <PropertyGroup>
         <RestoreSources Condition="'$(RestoreSources)'==''">
-            https://api.nuget.org/v3/index.json;
             https://pkgs.dev.azure.com/microsoft/ProjectReunion/_packaging/Project.Reunion.nuget.internal/nuget/v3/index.json
         </RestoreSources>
         <CppWinRTVersion Condition="'$(CppWinRTVersion)' == ''">2.0.210211.2</CppWinRTVersion>

--- a/dev/VSIX/packages.config
+++ b/dev/VSIX/packages.config
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Microsoft.VSSDK.BuildTools" version="16.9.1050" targetFramework="native" />
-</packages>


### PR DESCRIPTION
A few days ago I created a PR that created a pipeline to produce a signed VSIX. Said PR was merged into main and then cherrypicked ( #537  ) into release/project-reunion-2103. There, we saw that there were some extra things that were not needed, like an installation of VSSDK and we fixed them there. So now I am Cherry picking those changes into main as well :) 