### PR TITLE
Update ProjectCapability statically for now.

### DIFF
--- a/build/NuSpecs/Microsoft.ProjectReunion.Foundation.targets
+++ b/build/NuSpecs/Microsoft.ProjectReunion.Foundation.targets
@@ -5,6 +5,6 @@
   
   <ItemGroup>
     <ProjectCapability Id="VersionGeneral" Include="ProjectReunion.Foundation" />
-    <ProjectCapability Id="VersionSpecific" Include="ProjectReunion.Foundation.0.1.0-prerelease" />
+    <ProjectCapability Id="VersionSpecific" Include="ProjectReunion.Foundation.0.5.0-prerelease" />
   </ItemGroup>
 </Project>

--- a/build/NuSpecs/Microsoft.ProjectReunion.Foundation.targets
+++ b/build/NuSpecs/Microsoft.ProjectReunion.Foundation.targets
@@ -4,6 +4,7 @@
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.ApplicationModel.Resources.targets" />
   
   <ItemGroup>
-    <ProjectCapability Include="ProjectReunion" />
+    <ProjectCapability Id="VersionGeneral" Include="ProjectReunion.Foundation" />
+    <ProjectCapability Id="VersionSpecific" Include="ProjectReunion.Foundation.0.1.0-prerelease" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Still plumbing in how to do this in the pipeline in such a way that it "sticks" for consumers. So we'll just update this statically at the moment. 

VersionSpecific = ProjectReunion.Foundation.0.5.0-prerelease

Also changing the VersionGeneral tag to the more specific ProjectReunion.Foundation.

