### PR TITLE
cherry pick: GA tweaks - VS 16.9 prereq, WinUI 3 rename, remove UWP templates, Suspending event (#591)

### DIFF
--- a/dev/VSIX/Extension/ProjectReunion.Extension.csproj
+++ b/dev/VSIX/Extension/ProjectReunion.Extension.csproj
@@ -199,34 +199,6 @@
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <IncludeOutputGroupsInVSIX>TemplateProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
     </ProjectReference>
-    <ProjectReference Include="..\ProjectTemplates\UWP\CppWinRT\BlankApp\WinUI.UWP.CppWinRT.BlankApp.csproj">
-      <Project>{627B2125-97B1-4620-97AA-AD46B37AC9D1}</Project>
-      <Name>WinUI.UWP.CppWinRT.BlankApp</Name>
-      <VSIXSubPath>ProjectTemplates</VSIXSubPath>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <IncludeOutputGroupsInVSIX>TemplateProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
-    </ProjectReference>
-    <ProjectReference Include="..\ProjectTemplates\UWP\CSharp\BlankApp\WinUI.UWP.Cs.BlankApp.csproj">
-      <Project>{93abc6a8-319a-4291-b8e2-607d3272a4b4}</Project>
-      <Name>WinUI.UWP.Cs.BlankApp</Name>
-      <VSIXSubPath>ProjectTemplates</VSIXSubPath>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <IncludeOutputGroupsInVSIX>TemplateProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
-    </ProjectReference>
-    <ProjectReference Include="..\ProjectTemplates\UWP\CSharp\RuntimeComponent\WinUI.UWP.Cs.RuntimeComponent.csproj">
-      <Project>{824C3303-D492-4806-95CD-9AA20AB34BB3}</Project>
-      <Name>WinUI.UWP.Cs.RuntimeComponent</Name>
-      <VSIXSubPath>ProjectTemplates</VSIXSubPath>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <IncludeOutputGroupsInVSIX>TemplateProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
-    </ProjectReference>
-    <ProjectReference Include="..\ProjectTemplates\UWP\CSharp\ClassLibrary\WinUI.UWP.Cs.ClassLibrary.csproj">
-      <Project>{2A3D41EE-5641-4DEB-AC2C-B433CBC9174D}</Project>
-      <Name>WinUI.UWP.Cs.ClassLibrary</Name>
-      <VSIXSubPath>ProjectTemplates</VSIXSubPath>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <IncludeOutputGroupsInVSIX>TemplateProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="Exists('$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets')" />

--- a/dev/VSIX/Extension/source.extension.vsixmanifest
+++ b/dev/VSIX/Extension/source.extension.vsixmanifest
@@ -14,9 +14,9 @@
         <Preview>true</Preview>
     </Metadata>
     <Installation AllUsers="true">
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.8, 17.0)" />
-        <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[16.8, 17.0)" />
-        <InstallationTarget Id="Microsoft.VisualStudio.Enterprise" Version="[16.8, 17.0)" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.9, 17.0)" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[16.9, 17.0)" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Enterprise" Version="[16.9, 17.0)" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
@@ -46,9 +46,5 @@
         <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="WinUI.Neutral.CppWinRT.ResourceDictionary" d:TargetPath="|WinUI.Neutral.CppWinRT.ResourceDictionary;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
         <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="WinUI.Neutral.CppWinRT.RuntimeComponent" d:TargetPath="|WinUI.Neutral.CppWinRT.RuntimeComponent;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
         <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="WinUI.Neutral.Cs.ResourceDictionary" d:TargetPath="|WinUI.Neutral.Cs.ResourceDictionary;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
-        <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="WinUI.UWP.CppWinRT.BlankApp" d:TargetPath="|WinUI.UWP.CppWinRT.BlankApp;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
-        <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="WinUI.UWP.Cs.BlankApp" d:TargetPath="|WinUI.UWP.Cs.BlankApp;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
-        <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="WinUI.UWP.Cs.ClassLibrary" d:TargetPath="|WinUI.UWP.Cs.ClassLibrary;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
-        <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="WinUI.UWP.Cs.RuntimeComponent" d:TargetPath="|WinUI.UWP.Cs.RuntimeComponent;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
     </Assets>
 </PackageManifest>

--- a/dev/VSIX/ItemTemplates/Desktop/CSharp/BlankWindow/WinUI.Desktop.Cs.BlankWindow.vstemplate
+++ b/dev/VSIX/ItemTemplates/Desktop/CSharp/BlankWindow/WinUI.Desktop.Cs.BlankWindow.vstemplate
@@ -2,8 +2,8 @@
 <VSTemplate Version="3.0.0" Type="Item" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
   <TemplateData>
     <DefaultName>BlankWindow.xaml</DefaultName>
-    <Name>Blank Window (WinUI in Desktop)</Name>
-    <Description>A blank window for Desktop apps based on the Windows UI Library (WinUI).</Description>
+    <Name>Blank Window (WinUI 3 in Desktop)</Name>
+    <Description>A blank window for Desktop apps based on the Windows UI Library (WinUI 3).</Description>
     <Icon>WinUI.Desktop.Cs.BlankWindow.ico</Icon>
     <ProjectType>CSharp</ProjectType>
     <TemplateID>WinUI.Desktop.Cs.BlankWindow</TemplateID>

--- a/dev/VSIX/ItemTemplates/Desktop/CppWinRT/BlankWindow/WinUI.Desktop.CppWinRT.BlankWindow.vstemplate
+++ b/dev/VSIX/ItemTemplates/Desktop/CppWinRT/BlankWindow/WinUI.Desktop.CppWinRT.BlankWindow.vstemplate
@@ -2,8 +2,8 @@
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
   <TemplateData>
     <DefaultName>BlankWindow.xaml</DefaultName>
-    <Name>Blank Window (WinUI in Desktop)</Name>
-    <Description>A blank window for Desktop apps based on the Windows UI Library (WinUI).</Description>
+    <Name>Blank Window (WinUI 3 in Desktop)</Name>
+    <Description>A blank window for Desktop apps based on the Windows UI Library (WinUI 3).</Description>
     <Icon>WinUI.Desktop.CppWinRT.BlankWindow.ico</Icon>
     <ProjectType>VC</ProjectType>
     <TemplateID>WinUI.Desktop.CppWinRT.BlankWindow</TemplateID>

--- a/dev/VSIX/ItemTemplates/Neutral/CSharp/BlankPage/WinUI.Neutral.Cs.BlankPage.vstemplate
+++ b/dev/VSIX/ItemTemplates/Neutral/CSharp/BlankPage/WinUI.Neutral.Cs.BlankPage.vstemplate
@@ -2,8 +2,8 @@
 <VSTemplate Version="3.0.0" Type="Item" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
   <TemplateData>
     <DefaultName>BlankPage.xaml</DefaultName>
-    <Name>Blank Page (WinUI)</Name>
-    <Description>A blank page for apps based on the Windows UI Library (WinUI).</Description>
+    <Name>Blank Page (WinUI 3)</Name>
+    <Description>A blank page for apps based on the Windows UI Library (WinUI 3).</Description>
     <Icon>WinUI.Neutral.Cs.BlankPage.ico</Icon>
     <ProjectType>CSharp</ProjectType>
     <TemplateID>WinUI.Neutral.Cs.BlankPage</TemplateID>

--- a/dev/VSIX/ItemTemplates/Neutral/CSharp/ResourceDictionary/WinUI.Neutral.Cs.ResourceDictionary.vstemplate
+++ b/dev/VSIX/ItemTemplates/Neutral/CSharp/ResourceDictionary/WinUI.Neutral.Cs.ResourceDictionary.vstemplate
@@ -2,8 +2,8 @@
 <VSTemplate Version="3.0.0" Type="Item" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
   <TemplateData>
     <DefaultName>ResourceDictionary.xaml</DefaultName>
-    <Name>Resource Dictionary (WinUI)</Name>
-    <Description>An empty, keyed collection of XAML resources for apps based on the Windows UI Library (WinUI).</Description>
+    <Name>Resource Dictionary (WinUI 3)</Name>
+    <Description>An empty, keyed collection of XAML resources for apps based on the Windows UI Library (WinUI 3).</Description>
     <Icon>WinUI.Neutral.Cs.ResourceDictionary.ico</Icon>
     <ProjectType>CSharp</ProjectType>
     <TemplateID>WinUI.Cs.Neutral.ResourceDictionary</TemplateID>

--- a/dev/VSIX/ItemTemplates/Neutral/CSharp/Resw/WinUI.Neutral.Cs.Resw.vstemplate
+++ b/dev/VSIX/ItemTemplates/Neutral/CSharp/Resw/WinUI.Neutral.Cs.Resw.vstemplate
@@ -3,7 +3,7 @@
   <TemplateData>
     <DefaultName>Resources.resw</DefaultName>
     <Name>Resources File (.resw)</Name>
-    <Description>A file for storing string and conditional resources for apps based on the Windows UI Library (WinUI).</Description>
+    <Description>A file for storing string and conditional resources for apps based on the Windows UI Library (WinUI 3).</Description>
     <Icon>WinUI.Neutral.Cs.Resw.ico</Icon>
     <ProjectType>CSharp</ProjectType>
     <TemplateID>WinUI.Cs.Neutral.Resw</TemplateID>

--- a/dev/VSIX/ItemTemplates/Neutral/CSharp/TemplatedControl/WinUI.Neutral.Cs.TemplatedControl.vstemplate
+++ b/dev/VSIX/ItemTemplates/Neutral/CSharp/TemplatedControl/WinUI.Neutral.Cs.TemplatedControl.vstemplate
@@ -2,8 +2,8 @@
 <VSTemplate Version="3.0.0" Type="Item" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
   <TemplateData>
     <DefaultName>CustomControl.cs</DefaultName>
-    <Name>Custom Control (WinUI)</Name>
-    <Description>A custom control for apps based on the Windows UI Library (WinUI).</Description>
+    <Name>Custom Control (WinUI 3)</Name>
+    <Description>A custom control for apps based on the Windows UI Library (WinUI 3).</Description>
     <Icon>WinUI.Neutral.Cs.TemplatedControl.ico</Icon>
     <ProjectType>CSharp</ProjectType>
     <TemplateID>WinUI.Neutral.UWP.TemplatedControl</TemplateID>

--- a/dev/VSIX/ItemTemplates/Neutral/CSharp/UserControl/WinUI.Neutral.Cs.UserControl.vstemplate
+++ b/dev/VSIX/ItemTemplates/Neutral/CSharp/UserControl/WinUI.Neutral.Cs.UserControl.vstemplate
@@ -2,8 +2,8 @@
 <VSTemplate Version="3.0.0" Type="Item" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
   <TemplateData>
     <DefaultName>UserControl.xaml</DefaultName>
-    <Name>User Control (WinUI)</Name>
-    <Description>A user control for apps based on the Windows UI Library (WinUI).</Description>
+    <Name>User Control (WinUI 3)</Name>
+    <Description>A user control for apps based on the Windows UI Library (WinUI 3).</Description>
     <Icon>WinUI.Neutral.Cs.UserControl.ico</Icon>
     <ProjectType>CSharp</ProjectType>
     <TemplateID>WinUI.Cs.Neutral.UserControl</TemplateID>

--- a/dev/VSIX/ItemTemplates/Neutral/CppWinRT/BlankPage/WinUI.Neutral.CppWinRT.BlankPage.vstemplate
+++ b/dev/VSIX/ItemTemplates/Neutral/CppWinRT/BlankPage/WinUI.Neutral.CppWinRT.BlankPage.vstemplate
@@ -2,8 +2,8 @@
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
   <TemplateData>
     <DefaultName>BlankPage.xaml</DefaultName>
-    <Name>Blank Page (WinUI)</Name>
-    <Description>A blank page for apps based on the Windows UI Library (WinUI).</Description>
+    <Name>Blank Page (WinUI 3)</Name>
+    <Description>A blank page for apps based on the Windows UI Library (WinUI 3).</Description>
     <Icon>WinUI.Neutral.CppWinRT.BlankPage.ico</Icon>
     <ProjectType>VC</ProjectType>
     <TemplateID>WinUI.Neutral.CppWinRT.BlankPage</TemplateID>

--- a/dev/VSIX/ItemTemplates/Neutral/CppWinRT/ResourceDictionary/WinUI.Neutral.CppWinRT.ResourceDictionary.vstemplate
+++ b/dev/VSIX/ItemTemplates/Neutral/CppWinRT/ResourceDictionary/WinUI.Neutral.CppWinRT.ResourceDictionary.vstemplate
@@ -2,8 +2,8 @@
 <VSTemplate Version="3.0.0" Type="Item" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
   <TemplateData>
     <DefaultName>ResourceDictionary.xaml</DefaultName>
-    <Name>Resource Dictionary (WinUI)</Name>
-    <Description>An empty, keyed collection of XAML resources for apps based on the Windows UI Library (WinUI).</Description>
+    <Name>Resource Dictionary (WinUI 3)</Name>
+    <Description>An empty, keyed collection of XAML resources for apps based on the Windows UI Library (WinUI 3).</Description>
     <Icon>WinUI.Neutral.CppWinRT.ResourceDictionary.ico</Icon>
     <ProjectType>VC</ProjectType>
     <TemplateID>WinUI.Neutral.CppWinRT.ResourceDictionary</TemplateID>

--- a/dev/VSIX/ItemTemplates/Neutral/CppWinRT/Resw/WinUI.Neutral.CppWinRT.Resw.vstemplate
+++ b/dev/VSIX/ItemTemplates/Neutral/CppWinRT/Resw/WinUI.Neutral.CppWinRT.Resw.vstemplate
@@ -3,7 +3,7 @@
   <TemplateData>
     <DefaultName>Resources.resw</DefaultName>
     <Name>Resources File (.resw)</Name>
-    <Description>A file for storing string and conditional resources for apps based on the Windows UI Library (WinUI).</Description>
+    <Description>A file for storing string and conditional resources for apps based on the Windows UI Library (WinUI 3).</Description>
     <Icon>WinUI.Neutral.CppWinRT.Resw.ico</Icon>
     <ProjectType>VC</ProjectType>
     <TemplateID>WinUI.CppWinRT.Neutral.Resw</TemplateID>

--- a/dev/VSIX/ItemTemplates/Neutral/CppWinRT/TemplatedControl/WinUI.Neutral.CppWinRT.TemplatedControl.vstemplate
+++ b/dev/VSIX/ItemTemplates/Neutral/CppWinRT/TemplatedControl/WinUI.Neutral.CppWinRT.TemplatedControl.vstemplate
@@ -2,8 +2,8 @@
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
   <TemplateData>
     <DefaultName>CustomControl.cpp</DefaultName>
-    <Name>Custom Control (WinUI)</Name>
-    <Description>A custom control for apps based on the Windows UI Library (WinUI).</Description>
+    <Name>Custom Control (WinUI 3)</Name>
+    <Description>A custom control for apps based on the Windows UI Library (WinUI 3).</Description>
     <Icon>WinUI.Neutral.CppWinRT.TemplatedControl.ico</Icon>
     <ProjectType>VC</ProjectType>
     <TemplateID>WinUI.Neutral.CppWinRT.TemplatedControl</TemplateID>

--- a/dev/VSIX/ItemTemplates/Neutral/CppWinRT/UserControl/WinUI.Neutral.CppWinRT.UserControl.vstemplate
+++ b/dev/VSIX/ItemTemplates/Neutral/CppWinRT/UserControl/WinUI.Neutral.CppWinRT.UserControl.vstemplate
@@ -2,8 +2,8 @@
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
   <TemplateData>
     <DefaultName>UserControl.xaml</DefaultName>
-    <Name>User Control (WinUI)</Name>
-    <Description>A user control for apps based on the Windows UI Library (WinUI).</Description>
+    <Name>User Control (WinUI 3)</Name>
+    <Description>A user control for apps based on the Windows UI Library (WinUI 3).</Description>
     <Icon>WinUI.Neutral.CppWinRT.UserControl.ico</Icon>
     <ProjectType>VC</ProjectType>
     <TemplateID>WinUI.Neutral.CppWinRT.UserControl</TemplateID>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/ClassLibrary/WinUI.Desktop.Cs.ClassLibrary.vstemplate
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/ClassLibrary/WinUI.Desktop.Cs.ClassLibrary.vstemplate
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Project">
   <TemplateData>
-    <Name>Class Library (WinUI in Desktop)</Name>
-    <Description>A project for creating a managed class library (.dll) for Desktop apps based on the Windows UI Library (WinUI).</Description>
+    <Name>Class Library (WinUI 3 in Desktop)</Name>
+    <Description>A project for creating a managed class library (.dll) for Desktop apps based on the Windows UI Library (WinUI 3).</Description>
     <Icon>WinUI.Desktop.Cs.ClassLibrary.ico</Icon>
     <TemplateID>Microsoft.WinUI.Desktop.Cs.ClassLibrary</TemplateID>
     <TemplateGroupID>WinRT-Managed</TemplateGroupID>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/App.xaml.cs
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/App.xaml.cs
@@ -33,7 +33,6 @@ namespace $safeprojectname$
         public App()
         {
             this.InitializeComponent();
-            this.Suspending += OnSuspending;
         }
 
         /// <summary>
@@ -45,18 +44,6 @@ namespace $safeprojectname$
         {
             m_window = new MainWindow();
             m_window.Activate();
-        }
-
-        /// <summary>
-        /// Invoked when application execution is being suspended.  Application state is saved
-        /// without knowing whether the application will be terminated or resumed with the contents
-        /// of memory still intact.
-        /// </summary>
-        /// <param name="sender">The source of the suspend request.</param>
-        /// <param name="e">Details about the suspend request.</param>
-        private void OnSuspending(object sender, SuspendingEventArgs e)
-        {
-            // Save application state and stop any background activity
         }
 
         private Window m_window;

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/WinUI.Desktop.Cs.BlankApp.vstemplate
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/BlankApp/WinUI.Desktop.Cs.BlankApp.vstemplate
@@ -2,8 +2,8 @@
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Project">
   <TemplateData>
     <Hidden>true</Hidden>
-    <Name>Blank App (WinUI in Desktop)</Name>
-    <Description>A project for creating a Desktop app based on the Windows UI Library (WinUI).</Description>
+    <Name>Blank App (WinUI 3 in Desktop)</Name>
+    <Description>A project for creating a Desktop app based on the Windows UI Library (WinUI 3).</Description>
     <Icon>WinUI.Desktop.Cs.BlankApp.ico</Icon>
     <TemplateID>Microsoft.WinUI.Desktop.Cs.BlankApp</TemplateID>
     <TemplateGroupID>WinRT-Managed</TemplateGroupID>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/WapProj/WinUI.Desktop.Cs.WapProj.vstemplate
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/WapProj/WinUI.Desktop.Cs.WapProj.vstemplate
@@ -2,8 +2,8 @@
 <VSTemplate Version="3.0.0" Type="Project" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
   <TemplateData>
     <Hidden>true</Hidden>
-    <Name>Windows Application Packaging Project for WinUI</Name>
-    <Description>A project that creates MSIX packages containing WinUI in Desktop applications for side-loading or distribution via the Microsoft Store</Description>
+    <Name>Windows Application Packaging Project for WinUI 3</Name>
+    <Description>A project that creates MSIX packages containing WinUI 3 in Desktop applications for side-loading or distribution via the Microsoft Store</Description>
     <Icon>WapProjTemplate.ico</Icon>
     <ProjectType>CSharp</ProjectType>
     <TemplateID>WinUI.Desktop.Cs.WapProj</TemplateID>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/WinUI.Desktop.Cs.PackagedApp.vstemplate
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/WinUI.Desktop.Cs.PackagedApp.vstemplate
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="ProjectGroup">
   <TemplateData>
-    <Name>Blank App, Packaged (WinUI in Desktop)</Name>
-    <Description>A project for creating a Desktop app based on the Windows UI Library (WinUI) along with a MSIX package for side-loading or distribution via the Microsoft Store.</Description>
+    <Name>Blank App, Packaged (WinUI 3 in Desktop)</Name>
+    <Description>A project for creating a Desktop app based on the Windows UI Library (WinUI 3) along with a MSIX package for side-loading or distribution via the Microsoft Store.</Description>
     <Icon>WinUI.Desktop.Cs.PackagedApp.ico</Icon>
     <TemplateID>Microsoft.WinUI.Desktop.Cs.PackagedApp</TemplateID>
     <TemplateGroupID>WinRT-Managed</TemplateGroupID>

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/App.cpp
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/App.cpp
@@ -21,7 +21,6 @@ using namespace $safeprojectname$::implementation;
 App::App()
 {
     InitializeComponent();
-    Suspending({ this, &App::OnSuspending });
 
 #if defined _DEBUG && !defined DISABLE_XAML_GENERATED_BREAK_ON_UNHANDLED_EXCEPTION
     UnhandledException([this](IInspectable const&, UnhandledExceptionEventArgs const& e)
@@ -44,16 +43,4 @@ void App::OnLaunched(LaunchActivatedEventArgs const&)
 {
     window = make<MainWindow>();
     window.Activate();
-}
-
-/// <summary>
-/// Invoked when application execution is being suspended.  Application state is saved
-/// without knowing whether the application will be terminated or resumed with the contents
-/// of memory still intact.
-/// </summary>
-/// <param name="sender">The source of the suspend request.</param>
-/// <param name="e">Details about the suspend request.</param>
-void App::OnSuspending([[maybe_unused]] IInspectable const& sender, [[maybe_unused]] Windows::ApplicationModel::SuspendingEventArgs const& e)
-{
-    // Save application state and stop any background activity
 }

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/WinUI.Desktop.CppWinRT.BlankApp.vstemplate
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/BlankApp/WinUI.Desktop.CppWinRT.BlankApp.vstemplate
@@ -2,8 +2,8 @@
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Project">
   <TemplateData>
     <Hidden>true</Hidden>
-    <Name>Blank App (WinUI in Desktop)</Name>
-    <Description>A project for creating a Desktop app based on the Windows UI Library (WinUI).</Description>
+    <Name>Blank App (WinUI 3 in Desktop)</Name>
+    <Description>A project for creating a Desktop app based on the Windows UI Library (WinUI 3).</Description>
     <Icon>WinUI.Desktop.CppWinRT.BlankApp.ico</Icon>
     <TemplateID>Microsoft.WinUI.Desktop.CppWinRT.BlankApp</TemplateID>
     <ProjectType>VC</ProjectType>

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/WapProj/WinUI.Desktop.CppWinRT.WapProj.vstemplate
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/WapProj/WinUI.Desktop.CppWinRT.WapProj.vstemplate
@@ -2,8 +2,8 @@
 <VSTemplate Version="3.0.0" Type="Project" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
   <TemplateData>
     <Hidden>true</Hidden>
-    <Name>Windows Application Packaging Project for WinUI</Name>
-    <Description>A project that creates MSIX packages containing WinUI in Desktop applications for side-loading or distribution via the Microsoft Store</Description>
+    <Name>Windows Application Packaging Project for WinUI 3</Name>
+    <Description>A project that creates MSIX packages containing WinUI 3 in Desktop applications for side-loading or distribution via the Microsoft Store</Description>
     <Icon>WapProjTemplate.ico</Icon>
     <ProjectType>VC</ProjectType>
     <TemplateID>WinUI.Desktop.CppWinRT.WapProj</TemplateID>

--- a/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/WinUI.Desktop.CppWinRT.PackagedApp.vstemplate
+++ b/dev/VSIX/ProjectTemplates/Desktop/CppWinRT/PackagedApp/WinUI.Desktop.CppWinRT.PackagedApp.vstemplate
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="ProjectGroup">
   <TemplateData>
-    <Name>Blank App, Packaged (WinUI in Desktop)</Name>
-    <Description>A project for creating a Desktop app based on the Windows UI Library (WinUI) along with a MSIX package for side-loading or distribution via the Microsoft Store.</Description>
+    <Name>Blank App, Packaged (WinUI 3 in Desktop)</Name>
+    <Description>A project for creating a Desktop app based on the Windows UI Library (WinUI 3) along with a MSIX package for side-loading or distribution via the Microsoft Store.</Description>
     <Icon>WinUI.Desktop.CppWinRT.PackagedApp.ico</Icon>
     <TemplateID>Microsoft.WinUI.Desktop.CppWinRT.PackagedApp</TemplateID>
     <ProjectType>VC</ProjectType>

--- a/dev/VSIX/ProjectTemplates/Neutral/CppWinRT/RuntimeComponent/WinUI.Neutral.CppWinRT.RuntimeComponent.vstemplate
+++ b/dev/VSIX/ProjectTemplates/Neutral/CppWinRT/RuntimeComponent/WinUI.Neutral.CppWinRT.RuntimeComponent.vstemplate
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Project">
   <TemplateData>
-    <Name>Windows Runtime Component (WinUI)</Name>
-    <Description>A project for creating a C++/WinRT Windows Runtime Component (.winmd) for both Desktop and Universal Windows Platform (UWP) apps, based on the Windows UI Library (WinUI).</Description>
+    <Name>Windows Runtime Component (WinUI 3)</Name>
+    <Description>A project for creating a C++/WinRT Windows Runtime Component (.winmd) for both Desktop and Universal Windows Platform (UWP) apps, based on the Windows UI Library (WinUI 3).</Description>
     <Icon>WinUI.Neutral.CppWinRT.RuntimeComponent.ico</Icon>
     <TemplateID>Microsoft.WinUI.Neutral.CppWinRT.RuntimeComponent</TemplateID>
     <ProjectType>VC</ProjectType>

--- a/dev/VSIX/ProjectTemplates/UWP/CSharp/BlankApp/WinUI.UWP.Cs.BlankApp.vstemplate
+++ b/dev/VSIX/ProjectTemplates/UWP/CSharp/BlankApp/WinUI.UWP.Cs.BlankApp.vstemplate
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Project">
   <TemplateData>
-    <Name>Blank App (WinUI in UWP)</Name>
-    <Description>A project for creating a Universal Windows Platform (UWP) app based on the Windows UI Library (WinUI).</Description>
+    <Name>Blank App (WinUI 3 in UWP), Experimental</Name>
+    <Description>A project for creating a Universal Windows Platform (UWP) app based on the Windows UI Library (WinUI 3). Requires Project Reunion prerelease support.</Description>
     <Icon>WinUI.UWP.Cs.BlankApp.ico</Icon>
     <TemplateID>Microsoft.WinUI.UWP.Cs.BlankApp</TemplateID>
     <TemplateGroupID>WinRT-Managed</TemplateGroupID>

--- a/dev/VSIX/ProjectTemplates/UWP/CSharp/ClassLibrary/WinUI.UWP.Cs.ClassLibrary.vstemplate
+++ b/dev/VSIX/ProjectTemplates/UWP/CSharp/ClassLibrary/WinUI.UWP.Cs.ClassLibrary.vstemplate
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Project">
   <TemplateData>
-    <Name>Class Library (WinUI in UWP)</Name>
-    <Description>A project for creating a managed class library (.dll) for Universal Windows Platform (UWP) apps based on the Windows UI Library (WinUI).</Description>
+    <Name>Class Library (WinUI 3 in UWP), Experimental</Name>
+    <Description>A project for creating a managed class library (.dll) for Universal Windows Platform (UWP) apps based on the Windows UI Library (WinUI 3). Requires Project Reunion prerelease support.</Description>
     <Icon>WinUI.UWP.Cs.ClassLibrary.ico</Icon>
     <TemplateID>Microsoft.WinUI.UWP.Cs.ClassLibrary</TemplateID>
     <TemplateGroupID>WinRT-Managed</TemplateGroupID>

--- a/dev/VSIX/ProjectTemplates/UWP/CSharp/RuntimeComponent/WinUI.UWP.Cs.RuntimeComponent.vstemplate
+++ b/dev/VSIX/ProjectTemplates/UWP/CSharp/RuntimeComponent/WinUI.UWP.Cs.RuntimeComponent.vstemplate
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Project">
   <TemplateData>
-    <Name>Windows Runtime Component (WinUI in UWP)</Name>
-    <Description>A project for creating a managed Windows Runtime Component (.winmd) for Universal Windows Platform (UWP) apps, based on the Windows UI Library (WinUI).</Description>
+    <Name>Windows Runtime Component (WinUI 3 in UWP), Experimental</Name>
+    <Description>A project for creating a managed Windows Runtime Component (.winmd) for Universal Windows Platform (UWP) apps, based on the Windows UI Library (WinUI 3). Requires Project Reunion prerelease support.</Description>
     <Icon>WinUI.UWP.Cs.RuntimeComponent.ico</Icon>
     <TemplateID>Microsoft.WinUI.UWP.Cs.RuntimeComponent</TemplateID>
     <TemplateGroupID>WinRT-Managed</TemplateGroupID>

--- a/dev/VSIX/ProjectTemplates/UWP/CppWinRT/BlankApp/WinUI.UWP.CppWinRT.BlankApp.vstemplate
+++ b/dev/VSIX/ProjectTemplates/UWP/CppWinRT/BlankApp/WinUI.UWP.CppWinRT.BlankApp.vstemplate
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Project">
   <TemplateData>
-    <Name>Blank App (WinUI in UWP)</Name>
-    <Description>A project for creating a Universal Windows Platform (UWP) app based on the Windows UI Library (WinUI).</Description>
+    <Name>Blank App (WinUI 3 in UWP), Experimental</Name>
+    <Description>A project for creating a Universal Windows Platform (UWP) app based on the Windows UI Library (WinUI 3). Requires Project Reunion prerelease support.</Description>
     <Icon>WinUI.UWP.CppWinRT.BlankApp.ico</Icon>
     <TemplateID>Microsoft.WinUI.UWP.CppWinRT.BlankApp</TemplateID>
     <ProjectType>VC</ProjectType>


### PR DESCRIPTION
* GA tweaks - VS 16.9 prereq, WinUI 3 rename, UWP templates unsupported

* remove UWP templates - not supported in release

* remove experimental Suspending event