### PR TITLE
Add temporary trap to block calling DynamicDependencies (or Bootstrap) APIs if Elevated

### DIFF
--- a/dev/DynamicDependency/MsixDynamicDependency.cpp
+++ b/dev/DynamicDependency/MsixDynamicDependency.cpp
@@ -23,10 +23,14 @@ bool IsStaticPackageGraphEmpty()
 // Temporary check to prevent accidental misuse and false bug reports until we address Issue #567 https://github.com/microsoft/ProjectReunion/issues/567
 bool IsElevated(HANDLE token = nullptr)
 {
-    wistd::unique_ptr<TOKEN_MANDATORY_LABEL> tokenMandatoryLabel;
-    FAIL_FAST_IF_FAILED(wil::get_token_information_nothrow(tokenMandatoryLabel, !token ? GetCurrentThreadEffectiveToken() : token));
+    wistd::unique_ptr<TOKEN_MANDATORY_LABEL> tokenMandatoryLabel{ wil::get_token_information_failfast<TOKEN_MANDATORY_LABEL>(!token ? GetCurrentThreadEffectiveToken() : token) };
     const DWORD integrityLevel{ *GetSidSubAuthority((*tokenMandatoryLabel).Label.Sid, static_cast<DWORD>(static_cast<UCHAR>(*GetSidSubAuthorityCount((*tokenMandatoryLabel).Label.Sid) - 1))) };
     return integrityLevel >= SECURITY_MANDATORY_HIGH_RID;
+}
+
+void FailFastIfElevated()
+{
+    FAIL_FAST_HR_IF_MSG(HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED), IsElevated() || IsElevated(GetCurrentProcessToken()), "DynamicDependencies doesn't support elevation. See Issue #567 https://github.com/microsoft/ProjectReunion/issues/567");
 }
 }
 
@@ -40,8 +44,8 @@ STDAPI MddTryCreatePackageDependency(
     MddCreatePackageDependencyOptions options,
     _Outptr_result_maybenull_ PWSTR* packageDependencyId) noexcept try
 {
-    // Dynamic Dependencies doesn't support elevation
-    FAIL_FAST_HR_IF_MSG(HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED), MddCore::IsElevated() || MddCore::IsElevated(GetCurrentProcessToken()), "DynamicDependencies doesn't support elevation. See Issue #567 https://github.com/microsoft/ProjectReunion/issues/567");
+    // Dynamic Dependencies doesn't support elevation. See Issue #567 https://github.com/microsoft/ProjectReunion/issues/567
+    MddCore::FailFastIfElevated();
 
     *packageDependencyId = nullptr;
 
@@ -56,8 +60,8 @@ CATCH_RETURN();
 STDAPI_(void) MddDeletePackageDependency(
     _In_ PCWSTR packageDependencyId) noexcept try
 {
-    // Dynamic Dependencies doesn't support elevation
-    FAIL_FAST_HR_IF_MSG(HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED),MddCore::IsElevated() ||MddCore::IsElevated(GetCurrentProcessToken()), "DynamicDependencies doesn't support elevation. See Issue #567 https://github.com/microsoft/ProjectReunion/issues/567");
+    // Dynamic Dependencies doesn't support elevation. See Issue #567 https://github.com/microsoft/ProjectReunion/issues/567
+    MddCore::FailFastIfElevated();
 
     // Dynamic Dependencies requires a non-packaged process
     THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED), !MddCore::IsStaticPackageGraphEmpty());
@@ -73,8 +77,8 @@ STDAPI MddAddPackageDependency(
     _Out_ MDD_PACKAGEDEPENDENCY_CONTEXT* packageDependencyContext,
     _Outptr_opt_result_maybenull_ PWSTR* packageFullName) noexcept try
 {
-    // Dynamic Dependencies doesn't support elevation
-    FAIL_FAST_HR_IF_MSG(HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED),MddCore::IsElevated() ||MddCore::IsElevated(GetCurrentProcessToken()), "DynamicDependencies doesn't support elevation. See Issue #567 https://github.com/microsoft/ProjectReunion/issues/567");
+    // Dynamic Dependencies doesn't support elevation. See Issue #567 https://github.com/microsoft/ProjectReunion/issues/567
+    MddCore::FailFastIfElevated();
 
     *packageDependencyContext = nullptr;
     if (packageFullName)
@@ -93,8 +97,8 @@ CATCH_RETURN();
 STDAPI_(void) MddRemovePackageDependency(
     _In_ MDD_PACKAGEDEPENDENCY_CONTEXT packageDependencyContext) noexcept try
 {
-    // Dynamic Dependencies doesn't support elevation
-    FAIL_FAST_HR_IF_MSG(HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED),MddCore::IsElevated() ||MddCore::IsElevated(GetCurrentProcessToken()), "DynamicDependencies doesn't support elevation. See Issue #567 https://github.com/microsoft/ProjectReunion/issues/567");
+    // Dynamic Dependencies doesn't support elevation. See Issue #567 https://github.com/microsoft/ProjectReunion/issues/567
+    MddCore::FailFastIfElevated();
 
     // Dynamic Dependencies requires a non-packaged process
     LOG_HR_IF(HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED), !MddCore::IsStaticPackageGraphEmpty());
@@ -107,8 +111,8 @@ STDAPI MddGetResolvedPackageFullNameForPackageDependency(
     _In_ PCWSTR packageDependencyId,
     _Outptr_result_maybenull_ PWSTR* packageFullName) noexcept try
 {
-    // Dynamic Dependencies doesn't support elevation
-    FAIL_FAST_HR_IF_MSG(HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED),MddCore::IsElevated() ||MddCore::IsElevated(GetCurrentProcessToken()), "DynamicDependencies doesn't support elevation. See Issue #567 https://github.com/microsoft/ProjectReunion/issues/567");
+    // Dynamic Dependencies doesn't support elevation. See Issue #567 https://github.com/microsoft/ProjectReunion/issues/567
+    MddCore::FailFastIfElevated();
 
     *packageFullName = nullptr;
 
@@ -129,8 +133,8 @@ STDAPI MddGetIdForPackageDependencyContext(
     _In_ MDD_PACKAGEDEPENDENCY_CONTEXT packageDependencyContext,
     _Outptr_result_maybenull_ PWSTR* packageDependencyId) noexcept try
 {
-    // Dynamic Dependencies doesn't support elevation
-    FAIL_FAST_HR_IF_MSG(HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED),MddCore::IsElevated() ||MddCore::IsElevated(GetCurrentProcessToken()), "DynamicDependencies doesn't support elevation. See Issue #567 https://github.com/microsoft/ProjectReunion/issues/567");
+    // Dynamic Dependencies doesn't support elevation. See Issue #567 https://github.com/microsoft/ProjectReunion/issues/567
+    MddCore::FailFastIfElevated();
 
     *packageDependencyId = nullptr;
 

--- a/dev/ProjectReunion_BootstrapDLL/framework.h
+++ b/dev/ProjectReunion_BootstrapDLL/framework.h
@@ -15,6 +15,7 @@
 #include <mutex>
 
 #include <wil/cppwinrt.h>
+#include <wil/token_helpers.h>
 #include <wil/win32_helpers.h>
 #include <wil/result.h>
 #include <wil/com.h>


### PR DESCRIPTION
Adding a trap if DynDep|Bootstrap APIs are called from an Elevated process to prevent accidental misuse, false bug reports and bloodshed and tears all around.

This block will be removed when we address Issue #567 https://github.com/microsoft/ProjectReunion/issues/567