### PR TITLE
DynamicDependencies: Only Detour functions in not-packaged processes

### DIFF
--- a/test/DynamicDependency/Test_Win32/TestMddBootstrap.cpp
+++ b/test/DynamicDependency/Test_Win32/TestMddBootstrap.cpp
@@ -88,6 +88,35 @@ namespace Test::DynamicDependency
             MddBootstrapShutdown();
         }
 
+        TEST_METHOD(GetCurrentPackageInfo_NotPackaged_InvalidParameter)
+        {
+            const UINT32 c_filter{ PACKAGE_FILTER_HEAD | PACKAGE_FILTER_DIRECT | PACKAGE_INFORMATION_BASIC };
+
+            {
+                Assert::AreEqual(E_INVALIDARG, HRESULT_FROM_WIN32(::GetCurrentPackageInfo(c_filter, nullptr, nullptr, nullptr)));
+            }
+            {
+                UINT32 count{};
+                Assert::AreEqual(E_INVALIDARG, HRESULT_FROM_WIN32(::GetCurrentPackageInfo(c_filter, nullptr, nullptr, &count)));
+            }
+
+            {
+                UINT32 bufferLength{ 1 };
+                Assert::AreEqual(E_INVALIDARG, HRESULT_FROM_WIN32(::GetCurrentPackageInfo(c_filter, &bufferLength, nullptr, nullptr)));
+            }
+            {
+                UINT32 bufferLength{ 1 };
+                UINT32 count{};
+                Assert::AreEqual(E_INVALIDARG, HRESULT_FROM_WIN32(::GetCurrentPackageInfo(c_filter, &bufferLength, nullptr, &count)));
+            }
+
+            {
+                BYTE buffer[1]{};
+                UINT32 bufferLength{ static_cast<UINT32>(ARRAYSIZE(buffer)) };
+                Assert::AreEqual(E_INVALIDARG, HRESULT_FROM_WIN32(::GetCurrentPackageInfo(c_filter, &bufferLength, buffer, nullptr)));
+            }
+        }
+
         TEST_METHOD(GetCurrentPackageInfo_NotPackaged)
         {
             VerifyGetCurrentPackageInfo();

--- a/test/DynamicDependency/Test_Win32/pch.h
+++ b/test/DynamicDependency/Test_Win32/pch.h
@@ -19,6 +19,8 @@
 #include <winrt/Windows.Foundation.Collections.h>
 
 #include <winrt/Windows.ApplicationModel.h>
+#include <winrt/Windows.ApplicationModel.AppExtensions.h>
+#include <winrt/Windows.Management.Core.h>
 #include <winrt/Windows.Management.Deployment.h>
 
 #include <filesystem>


### PR DESCRIPTION
DynamicDependencies only supports not-packaged processes but the Detours hooks were always wired up. Fixed to skip skip that in a packaged process so Microsoft.ProjectReunion.dll can be used in packaged processes for other (not DynDep) features.

Also beefed up parameter validation in the Detour'd GetCurrentPackageInfo[2] to match the OS APIs' parameter validation.

Expanded test cases.

NOTE: Tests verifying package'd process behavior is blocked awaiting [Rewrite DynamicDependencies tests using TAEF #559](https://github.com/microsoft/ProjectReunion/issues/559)