### PR TITLE
Remove unnecessary Pkg* defines and avoid bad vsix builds when nuget restore fails 

### DIFF
--- a/dev/VSIX/Directory.Build.props
+++ b/dev/VSIX/Directory.Build.props
@@ -18,16 +18,6 @@
         <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
         <VSIXBuild>true</VSIXBuild>
         <RuntimeIdentifiers>win</RuntimeIdentifiers>
-        
-        <!--PackageReference.GeneratePathProperty does not support NUGET_PACKAGES env var...-->
-        <NuGetPackageRoot Condition="'$(NuGetPackageRoot)'==''">$(NUGET_PACKAGES)</NuGetPackageRoot>
-        <NuGetPackageRoot Condition="'$(NuGetPackageRoot)'==''">$(UserProfile)\.nuget\packages</NuGetPackageRoot>
-        <PkgMicrosoft_Windows_CppWinRT Condition="'$(PkgMicrosoft_Windows_CppWinRT)'==''">$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)', 'Microsoft.Windows.CppWinRT', '$(CppWinRTVersion)'))</PkgMicrosoft_Windows_CppWinRT>
-        <PkgMicrosoft_ProjectReunion Condition="'$(PkgMicrosoft_ProjectReunion)'==''">$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)', 'Microsoft.ProjectReunion', '$(ReunionVersion)'))</PkgMicrosoft_ProjectReunion>
-        <PkgMicrosoft_ProjectReunion_Foundation Condition="'$(PkgMicrosoft_ProjectReunion_Foundation)'==''">$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)', 'Microsoft.ProjectReunion.Foundation', '$(ReunionFoundationVersion)'))</PkgMicrosoft_ProjectReunion_Foundation>
-        <PkgMicrosoft_ProjectReunion_DWrite Condition="'$(PkgMicrosoft_ProjectReunion_DWrite)'==''">$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)', 'Microsoft.ProjectReunion.DWrite', '$(ReunionDWriteVersion)'))</PkgMicrosoft_ProjectReunion_DWrite>
-        <PkgMicrosoft_ProjectReunion_WinUI Condition="'$(PkgMicrosoft_ProjectReunion_WinUI)'==''">$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)', 'Microsoft.ProjectReunion.WinUI', '$(ReunionWinUIVersion)'))</PkgMicrosoft_ProjectReunion_WinUI>
-
         <BuildOutput Condition="'$(BuildOutput)' == ''">$(SolutionDir)BuildOutput\</BuildOutput>
         <BuildOutputRoot>$(BuildOutput)obj\$(Platform)$(Configuration)\</BuildOutputRoot>
         <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'==''">$(BuildOutputRoot)$(ProjectRelativePath)\</BaseIntermediateOutputPath>

--- a/dev/VSIX/Extension/ProjectReunion.Extension.csproj
+++ b/dev/VSIX/Extension/ProjectReunion.Extension.csproj
@@ -30,32 +30,21 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="LICENSE">
+    <ContentNugetPackages Include="$(PkgMicrosoft_Windows_CppWinRT)\*.nupkg"/>
+    <ContentNugetPackages Include="$(PkgMicrosoft_ProjectReunion)\*.nupkg"/>
+    <ContentNugetPackages Include="$(PkgMicrosoft_ProjectReunion_Foundation)\*.nupkg"/>
+    <ContentNugetPackages Include="$(PkgMicrosoft_ProjectReunion_DWrite)\*.nupkg"/>
+    <ContentNugetPackages Include="$(PkgMicrosoft_ProjectReunion_WinUI)\*.nupkg"/>
+    <Content Include="@(ContentNugetPackages)">
       <IncludeInVSIX>true</IncludeInVSIX>
+      <VSIXSubPath>Packages</VSIXSubPath>
     </Content>
     <Content Include="Reunion.png">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="$(PkgMicrosoft_Windows_CppWinRT)\*.nupkg">
+    <Content Include="LICENSE">
       <IncludeInVSIX>true</IncludeInVSIX>
-      <VSIXSubPath>Packages</VSIXSubPath>
-    </Content>
-    <Content Include="$(PkgMicrosoft_ProjectReunion)\*.nupkg">
-      <IncludeInVSIX>true</IncludeInVSIX>
-      <VSIXSubPath>Packages</VSIXSubPath>
-    </Content>
-    <Content Include="$(PkgMicrosoft_ProjectReunion_Foundation)\*.nupkg">
-      <IncludeInVSIX>true</IncludeInVSIX>
-      <VSIXSubPath>Packages</VSIXSubPath>
-    </Content>
-    <Content Include="$(PkgMicrosoft_ProjectReunion_DWrite)\*.nupkg">
-      <IncludeInVSIX>true</IncludeInVSIX>
-      <VSIXSubPath>Packages</VSIXSubPath>
-    </Content>
-    <Content Include="$(PkgMicrosoft_ProjectReunion_WinUI)\*.nupkg">
-      <IncludeInVSIX>true</IncludeInVSIX>
-      <VSIXSubPath>Packages</VSIXSubPath>
     </Content>
   </ItemGroup>
   <ItemGroup>
@@ -222,6 +211,7 @@
   <Target Name="GetVSIXVersion" Outputs="$(VSIXVersion)" />
   <Target Name="BeforeBuild">
     <Copy SourceFiles="..\..\..\LICENSE" DestinationFolder="$(MSBuildProjectDirectory)" />
+    <Error Text="Failed to restore one or more content nuget packages" Condition="'@(ContentNugetPackages->Count())' &lt; 5" />
   </Target>
   <Target Name="AfterBuild">
     <PropertyGroup>


### PR DESCRIPTION
still investigating why nuget restores are behaving inconsistently.  when they do fail, the vsix build should also fail.