### PR TITLE
Adding the ability to get an environment variable and set an environment variable

### DIFF
--- a/ProjectReunion.sln
+++ b/ProjectReunion.sln
@@ -39,9 +39,14 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Microsoft.Process.Environme
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "EnvironmentManagerTests", "test\EnvironmentManagerTests\EnvironmentManagerTests.vcxproj", "{333C2A4D-6599-40E1-90F8-F184C3CF6031}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ChangeTracker", "ChangeTracker", "{51171BC9-2699-4223-84F1-44AA52C1BA9D}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ChangeTracker", "dev\ChangeTracker\ChangeTracker.vcxitems", "{1ACACB1E-5867-4917-83FF-2B815F000B09}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		dev\Microsoft.Process.Environment\Microsoft.Process.Environment.vcxitems*{01fd7e2d-cf9b-48a0-b280-b698d18b51f0}*SharedItemsImports = 9
+		dev\ChangeTracker\ChangeTracker.vcxitems*{1acacb1e-5867-4917-83ff-2b815f000b09}*SharedItemsImports = 9
 		test\CppShared\CppShared.vcxitems*{682ded8c-3a27-48cd-866d-e853ea2024de}*SharedItemsImports = 9
 		test\inc\inc.vcxitems*{7c502995-59c3-483b-86ba-815985353633}*SharedItemsImports = 4
 		test\AppLifecycle\AppLifecycle.vcxitems*{80e07022-9e99-44fe-b875-901fb6c82f52}*SharedItemsImports = 9
@@ -191,6 +196,8 @@ Global
 		{BCE64BEB-DE10-4150-B1A5-502D151227FE} = {448ED2E5-0B37-4D97-9E6B-8C10A507976A}
 		{01FD7E2D-CF9B-48A0-B280-B698D18B51F0} = {BCE64BEB-DE10-4150-B1A5-502D151227FE}
 		{333C2A4D-6599-40E1-90F8-F184C3CF6031} = {8630F7AA-2969-4DC9-8700-9B468C1DC21D}
+		{51171BC9-2699-4223-84F1-44AA52C1BA9D} = {448ED2E5-0B37-4D97-9E6B-8C10A507976A}
+		{1ACACB1E-5867-4917-83FF-2B815F000B09} = {51171BC9-2699-4223-84F1-44AA52C1BA9D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4B3D7591-CFEC-4762-9A07-ABE99938FB77}

--- a/dev/ChangeTracker/ChangeTracker.vcxitems
+++ b/dev/ChangeTracker/ChangeTracker.vcxitems
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <MSBuildAllProjects Condition="'$(MSBuildVersion)' == '' Or '$(MSBuildVersion)' &lt; '16.0'">$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <ItemsProjectGuid>{1acacb1e-5867-4917-83ff-2b815f000b09}</ItemsProjectGuid>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(MSBuildThisFileDirectory)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ProjectCapability Include="SourceItemsFromImports" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="$(MSBuildThisFileDirectory)EnvironmentVariableChangeTracker.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)IChangeTracker.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="$(MSBuildThisFileDirectory)EnvironmentVariableChangeTracker.cpp" />
+  </ItemGroup>
+</Project>

--- a/dev/ChangeTracker/EnvironmentVariableChangeTracker.cpp
+++ b/dev/ChangeTracker/EnvironmentVariableChangeTracker.cpp
@@ -1,0 +1,86 @@
+﻿#include <pch.h>
+#include <EnvironmentVariableChangeTracker.h>
+
+namespace winrt::Microsoft::ProjectReunion::implementation
+{
+
+    EnvironmentVariableChangeTracker::EnvironmentVariableChangeTracker(std::wstring const& key, std::wstring const& valueToSet, EnvironmentManager::Scope scope)
+    {
+        if (key.empty())
+        {
+            THROW_HR(E_INVALIDARG);
+        }
+
+        // Check if we need to track the changes.
+        // If we do need to track the changes get the Package Full Name
+        UINT32 sizeOfBuffer{};
+        long fullNameResult = ::GetCurrentPackageFullName(&sizeOfBuffer, nullptr);
+
+        if (scope == EnvironmentManager::Scope::Process || fullNameResult == APPMODEL_ERROR_NO_PACKAGE)
+        {
+            m_ShouldTrackChange = false;
+        }
+        else if (fullNameResult == ERROR_INSUFFICIENT_BUFFER)
+        {
+            std::unique_ptr<WCHAR> packageFullName(new WCHAR[sizeOfBuffer]);
+
+            LONG getNameResult = ::GetCurrentPackageFullName(&sizeOfBuffer, packageFullName.get());
+            THROW_IF_FAILED(HRESULT_FROM_WIN32(getNameResult));
+            m_PackageFullName = std::wstring(packageFullName.get());
+            m_ShouldTrackChange = true;
+        }
+        else
+        {
+            THROW_HR(HRESULT_FROM_WIN32(fullNameResult));
+        }
+
+        m_Scope = scope;
+        m_Key = key;
+        m_Value = valueToSet;
+    }
+
+    std::wstring EnvironmentVariableChangeTracker::KeyName()
+    {
+        return L"EnvironmentVariables";
+    }
+
+    HRESULT EnvironmentVariableChangeTracker::TrackChange(std::function<HRESULT(void)> callback)
+    {
+        if (m_ShouldTrackChange)
+        {
+            wil::unique_hkey regLocationToWriteChange = GetKeyForTrackingChange();
+            // It is possible that the same package in the same scope
+            // will update an EV.  If this is the case we don't need to store
+            // the previous value since we already did that.
+            // All we need to do is record the new value and a new insertion time.
+            bool isCreatingEVForPackage = IsEVBeingCreated(regLocationToWriteChange.get());
+
+            if (isCreatingEVForPackage)
+            {
+                std::wstring originalValue = GetOriginalValueOfEV();
+                RETURN_IF_FAILED(HRESULT_FROM_WIN32(RegSetValueEx(regLocationToWriteChange.get()
+                    , L"PreviousValue"
+                    , 0
+                    , REG_SZ
+                    , reinterpret_cast<const BYTE*>(originalValue.c_str()), static_cast<DWORD>((originalValue.size() + 1) * sizeof(wchar_t)))));
+
+            }
+
+            RETURN_IF_FAILED(HRESULT_FROM_WIN32(RegSetValueEx(regLocationToWriteChange.get()
+                , L"CurrentValue"
+                , 0
+                , REG_SZ
+                , reinterpret_cast<const BYTE*>(m_Value.c_str()), static_cast<DWORD>((m_Value.size() + 1) * sizeof(wchar_t)))));
+
+            std::chrono::nanoseconds insertionTime = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch());
+            long long nanoSecondTicks = insertionTime.count();
+            RETURN_IF_FAILED(HRESULT_FROM_WIN32(RegSetValueEx(regLocationToWriteChange.get()
+                , L"InsertionTime"
+                , 0
+                , REG_QWORD
+                , reinterpret_cast<const BYTE*>(&nanoSecondTicks), sizeof(long long))));
+        }
+
+        return callback();
+    }
+}

--- a/dev/ChangeTracker/EnvironmentVariableChangeTracker.h
+++ b/dev/ChangeTracker/EnvironmentVariableChangeTracker.h
@@ -1,0 +1,143 @@
+﻿#pragma once
+#include <EnvironmentManager.h>
+#include "IChangeTracker.h"
+#include <wil/registry.h>
+
+using namespace winrt::Windows::Foundation::Collections;
+namespace winrt::Microsoft::ProjectReunion::implementation
+{
+    struct EnvironmentVariableChangeTracker : public IChangeTracker
+    {
+        EnvironmentVariableChangeTracker(std::wstring const& key, std::wstring const& valueToSet, EnvironmentManager::Scope scope);
+        HRESULT TrackChange(std::function<HRESULT(void)> callBack);
+
+    private:
+        const std::wstring c_userEvRegLocation = L"Environment";
+        const std::wstring c_machineEvRegLocation = L"SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment";
+
+
+        EnvironmentManager::Scope m_Scope;
+        std::wstring m_Key;
+        std::wstring m_Value;
+
+        std::wstring KeyName();
+
+        wil::unique_hkey GetRegHKeyForEVUserAndMachineScope()
+        {
+            assert(m_Scope != EnvironmentManager::Scope::Process);
+
+            wil::unique_hkey environmentVariablesHKey;
+            if (m_Scope == EnvironmentManager::Scope::User)
+            {
+                THROW_IF_FAILED(HRESULT_FROM_WIN32(RegOpenKeyEx(HKEY_CURRENT_USER, c_userEvRegLocation.c_str(), 0, KEY_READ, environmentVariablesHKey.addressof())));
+            }
+            else //Scope is Machine
+            {
+                THROW_IF_FAILED(HRESULT_FROM_WIN32(RegOpenKeyEx(HKEY_LOCAL_MACHINE, c_machineEvRegLocation.c_str(), 0, KEY_READ, environmentVariablesHKey.addressof())));
+            }
+
+            return environmentVariablesHKey;
+        }
+
+        wil::unique_hkey GetKeyForTrackingChange()
+        {
+            std::wstringstream subKeyStream;
+            subKeyStream << L"Software\\ChangeTracker\\";
+            subKeyStream << KeyName();
+            subKeyStream << L"\\";
+            subKeyStream << m_PackageFullName;
+            subKeyStream << "\\";
+            subKeyStream << m_Key;
+            subKeyStream << "\\";
+
+            if (m_Scope == EnvironmentManager::Scope::User)
+            {
+                subKeyStream << L"User";
+            }
+            else
+            {
+                subKeyStream << L"Machine";
+            }
+
+            subKeyStream << "\\";
+
+
+            wil::unique_hkey keyToTrackChanges;
+            if (m_Scope == EnvironmentManager::Scope::User)
+            {
+                THROW_IF_FAILED(HRESULT_FROM_WIN32(RegCreateKeyEx(HKEY_CURRENT_USER
+                    , subKeyStream.str().c_str()
+                    , 0
+                    , nullptr
+                    , REG_OPTION_NON_VOLATILE
+                    , KEY_ALL_ACCESS
+                    , nullptr
+                    , keyToTrackChanges.put()
+                    , nullptr)));
+            }
+            else //Machine level scope
+            {
+                THROW_IF_FAILED(HRESULT_FROM_WIN32(RegCreateKeyEx(HKEY_LOCAL_MACHINE
+                    , subKeyStream.str().c_str()
+                    , 0
+                    , nullptr
+                    , REG_OPTION_NON_VOLATILE
+                    , KEY_WRITE
+                    , nullptr
+                    , keyToTrackChanges.put()
+                    , nullptr)));
+            }
+
+            return keyToTrackChanges;
+        }
+
+        bool IsEVBeingCreated(HKEY keyToChangeTracker)
+        {
+            LSTATUS queryStatus = RegQueryValueEx(keyToChangeTracker, L"PreviousValue", 0, nullptr, nullptr, nullptr);
+
+            if (queryStatus == ERROR_FILE_NOT_FOUND)
+            {
+                return true;
+            }
+            else if (queryStatus == ERROR_SUCCESS)
+            {
+                return false;
+            }
+            else
+            {
+                THROW_HR(HRESULT_FROM_WIN32(queryStatus));
+            }
+
+
+        }
+
+        std::wstring GetOriginalValueOfEV()
+        {
+            wil::unique_hkey environmentVariableHKey = GetRegHKeyForEVUserAndMachineScope();
+            return QueryEvFromRegistry(m_Key, environmentVariableHKey.get());
+        }
+
+        std::wstring QueryEvFromRegistry(std::wstring variableKey, HKEY KeyToOpen)
+        {
+            DWORD sizeOfEnvironmentValue;
+
+            // See how big we need the buffer to be
+            LSTATUS queryResult = RegQueryValueEx(KeyToOpen, variableKey.c_str(), 0, nullptr, nullptr, &sizeOfEnvironmentValue);
+
+            if (queryResult != ERROR_SUCCESS)
+            {
+                if (queryResult == ERROR_FILE_NOT_FOUND)
+                {
+                    return L"";
+                }
+
+                THROW_HR(HRESULT_FROM_WIN32((queryResult)));
+            }
+
+            std::unique_ptr<wchar_t[]> environmentValue(new wchar_t[sizeOfEnvironmentValue]);
+            THROW_IF_FAILED(HRESULT_FROM_WIN32((RegQueryValueEx(KeyToOpen, variableKey.c_str(), 0, nullptr, (LPBYTE)environmentValue.get(), &sizeOfEnvironmentValue))));
+
+            return std::wstring(environmentValue.get());
+        }
+    };
+}

--- a/dev/ChangeTracker/IChangeTracker.h
+++ b/dev/ChangeTracker/IChangeTracker.h
@@ -1,0 +1,19 @@
+﻿#pragma once
+#include <string>
+#include <functional>
+#include <windows.h>
+
+namespace winrt::Microsoft::ProjectReunion::implementation
+{
+    class IChangeTracker {
+    public:
+        virtual HRESULT TrackChange(std::function<HRESULT(void)> callBack) = 0;
+
+        bool m_ShouldTrackChange = false;
+        std::wstring m_PackageFullName;
+
+    private:
+        virtual std::wstring KeyName() = 0;
+
+    };
+}

--- a/dev/Microsoft.Process.Environment/EnvironmentManager.h
+++ b/dev/Microsoft.Process.Environment/EnvironmentManager.h
@@ -23,7 +23,7 @@ namespace winrt::Microsoft::ProjectReunion::implementation
         static Microsoft::ProjectReunion::EnvironmentManager GetForUser();
         static Microsoft::ProjectReunion::EnvironmentManager GetForMachine();
         Windows::Foundation::Collections::IMapView<hstring, hstring> GetEnvironmentVariables();
-        hstring GetEnvironmentVariable(hstring const& name);
+        hstring GetEnvironmentVariable(hstring const& variableName);
         void SetEnvironmentVariable(hstring const& name, hstring const& value);
         void AppendToPath(hstring const& path);
         void RemoveFromPath(hstring const& path);
@@ -37,8 +37,40 @@ namespace winrt::Microsoft::ProjectReunion::implementation
         PCWSTR MACHINE_EV_REG_LOCATION = L"SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment";
 
         StringMap GetProcessEnvironmentVariables() const;
+        std::wstring GetProcessEnvironmentVariable(const std::wstring variableName) const;
+
         StringMap GetUserOrMachineEnvironmentVariables() const;
+        std::wstring GetUserOrMachineEnvironmentVariable(const std::wstring variableName) const;
         wil::unique_hkey GetRegHKeyForEVUserAndMachineScope(bool needsWriteAccess = false) const;
+
+        bool IsCurrentOS20H2OrLower()
+        {
+            OSVERSIONINFOEXW osvi = { sizeof(osvi), 0, 0, 0, 0, {0}, 0, 0 };
+            DWORDLONG const dwlConditionMask = VerSetConditionMask(0, VER_BUILDNUMBER, VER_LESS_EQUAL);
+            osvi.dwBuildNumber = 19042;
+
+            BOOL versionVerification = VerifyVersionInfoW(&osvi, VER_BUILDNUMBER, dwlConditionMask);
+
+            // If the OS the API is running on is 20H2 or lower
+            if (versionVerification != 0)
+            {
+                return true;
+            }
+            else
+            {
+                // Either the OS is higher than 20H2 or there is an error.
+                DWORD error = GetLastError();
+
+                if (error == ERROR_OLD_WIN_VERSION)
+                {
+                    return false;
+                }
+                else
+                {
+                    THROW_HR(HRESULT_FROM_WIN32(error));
+                }
+            }
+        }
     };
 }
 namespace winrt::Microsoft::ProjectReunion::factory_implementation

--- a/dev/ProjectReunion_DLL/ProjectReunion_DLL.vcxproj
+++ b/dev/ProjectReunion_DLL/ProjectReunion_DLL.vcxproj
@@ -106,6 +106,7 @@
   <ImportGroup Label="Shared">
     <Import Project="..\AppLifecycle\AppLifecycle.vcxitems" Label="AppLifecycle" />
     <Import Project="..\Microsoft.Process.Environment\Microsoft.Process.Environment.vcxitems" Label="Environment" />
+	<Import Project="..\ChangeTracker\ChangeTracker.vcxitems" Label="ChangeTracker" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />

--- a/test/EnvironmentManagerTests/ChangeTrackerHelper.h
+++ b/test/EnvironmentManagerTests/ChangeTrackerHelper.h
@@ -1,0 +1,46 @@
+﻿#pragma once
+
+inline wil::unique_hkey GetKeyForTrackingChange(bool isUser)
+{
+    wil::unique_hkey keyToTrackChanges;
+    if (isUser)
+    {
+        THROW_IF_FAILED(HRESULT_FROM_WIN32(RegCreateKeyEx(HKEY_CURRENT_USER
+            , L"Software\\ChangeTracker"
+            , 0
+            , nullptr
+            , REG_OPTION_NON_VOLATILE
+            , KEY_ALL_ACCESS
+            , nullptr
+            , keyToTrackChanges.put()
+            , nullptr)));
+    }
+    else //Machine level scope
+    {
+        THROW_IF_FAILED(HRESULT_FROM_WIN32(RegCreateKeyEx(HKEY_LOCAL_MACHINE
+            , L"Software\\ChangeTracker"
+            , 0
+            , nullptr
+            , REG_OPTION_NON_VOLATILE
+            , KEY_WRITE
+            , nullptr
+            , keyToTrackChanges.put()
+            , nullptr)));
+    }
+
+    return keyToTrackChanges;
+}
+
+inline void RemoveUserChangeTracking()
+{
+    wil::unique_hkey hKey = GetKeyForTrackingChange(true);
+
+    VERIFY_WIN32_SUCCEEDED(RegDeleteTree(hKey.get(), nullptr));
+}
+
+inline void RemoveMachineChangeTracking()
+{
+    wil::unique_hkey hKey = GetKeyForTrackingChange(false);
+
+    VERIFY_WIN32_SUCCEEDED(RegDeleteTree(hKey.get(), nullptr));
+}

--- a/test/EnvironmentManagerTests/EnvironmentManagerCentennialTests.cpp
+++ b/test/EnvironmentManagerTests/EnvironmentManagerCentennialTests.cpp
@@ -4,6 +4,8 @@
 #include "pch.h"
 #include "EnvironmentManagerCentennialTests.h"
 #include "EnvironmentVariableHelper.h"
+#include "ChangeTrackerHelper.h"
+#include "TestSetupAndTeardownHelper.h"
 
 using namespace winrt::Microsoft::ProjectReunion;
 
@@ -56,5 +58,112 @@ namespace ProjectReunionEnvironmentManagerTests
         EnvironmentVariables environmentVariablesFromWinRTAPI = environmentmanager.GetEnvironmentVariables();
 
         CompareIMapViews(environmentVariablesFromWinRTAPI, environmentVariablesFromWindowsAPI);
+    }
+
+    void EnvironmentManagerCentennialTests::CentennialTestGetEnvironmentVariableForProcess()
+    {
+        EnvironmentManager environmentManager = EnvironmentManager::GetForProcess();
+        winrt::hstring environmentValue = environmentManager.GetEnvironmentVariable(c_evKeyName);
+
+        VERIFY_ARE_EQUAL(std::wstring(c_evValueName), environmentValue);
+    }
+
+    void EnvironmentManagerCentennialTests::CentennialTestGetEnvironmentVariableForUser()
+    {
+        EnvironmentManager environmentManager = EnvironmentManager::GetForUser();
+        winrt::hstring environmentValue = environmentManager.GetEnvironmentVariable(c_evKeyName);
+        VERIFY_ARE_EQUAL(std::wstring(c_evValueName), environmentValue);
+    }
+
+    void EnvironmentManagerCentennialTests::CentennialTestGetEnvironmentVariableForMachine()
+    {
+        EnvironmentManager environmentManager = EnvironmentManager::GetForMachine();
+        winrt::hstring environmentValue = environmentManager.GetEnvironmentVariable(c_evKeyName);
+
+        VERIFY_ARE_EQUAL(std::wstring(c_evValueName), environmentValue);
+    }
+
+    void EnvironmentManagerCentennialTests::CentennialTestSetEnvironmentVariableForProcess()
+    {
+        EnvironmentManager environmentManager = EnvironmentManager::GetForProcess();
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName2, c_evValueName));
+
+        std::wstring writtenEV = GetEnvironmentVariableForProcess(c_evKeyName2);
+        VERIFY_ARE_EQUAL(std::wstring(c_evValueName), writtenEV);
+
+        // Update the environment variable
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName2, c_evValueName2));
+        writtenEV = GetEnvironmentVariableForProcess(c_evKeyName2);
+        VERIFY_ARE_EQUAL(std::wstring(c_evValueName2), writtenEV);
+
+
+        // Remove the value
+        // setting the value to empty is the same as deleting the variable
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName2, L""));
+        VERIFY_ARE_EQUAL(0, ::GetEnvironmentVariable(c_evKeyName2, nullptr, 0));
+        VERIFY_ARE_EQUAL(ERROR_ENVVAR_NOT_FOUND, GetLastError());
+
+        // Test the change tracker
+        wil::unique_hkey trackingChangeHKey = GetKeyForTrackingChange(true);
+
+        wil::unique_hkey trackingValueHKey;
+        VERIFY_WIN32_SUCCEEDED(RegOpenKeyEx(trackingChangeHKey.get(), c_trackerKeyLocationForUser().c_str(), 0, KEY_ALL_ACCESS, trackingValueHKey.put()));
+
+        // PreviousValue will be 0 because the EV did not exist.
+        DWORD sizeOfEnvironmentValue = 2;
+        std::unique_ptr<wchar_t[]> environmentValue(new wchar_t[sizeOfEnvironmentValue]);
+        VERIFY_WIN32_SUCCEEDED(RegQueryValueEx(trackingValueHKey.get(), L"PreviousValue", 0, nullptr, (LPBYTE)environmentValue.get(), &sizeOfEnvironmentValue));
+
+        VERIFY_ARE_EQUAL(L"", std::wstring(environmentValue.get()));
+
+        sizeOfEnvironmentValue = 2;
+        environmentValue.reset(new wchar_t[sizeOfEnvironmentValue]);
+        VERIFY_WIN32_SUCCEEDED(RegQueryValueEx(trackingValueHKey.get(), L"CurrentValue", 0, nullptr, (LPBYTE)environmentValue.get(), &sizeOfEnvironmentValue));
+
+        VERIFY_ARE_EQUAL(L"", std::wstring(environmentValue.get()));
+
+        RemoveUserChangeTracking();
+    }
+
+    void EnvironmentManagerCentennialTests::CentennialTestSetEnvironmentVariableForUser()
+    {
+        // Set 1 value.
+        EnvironmentManager environmentManager = EnvironmentManager::GetForUser();
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName2, c_evValueName));
+        std::wstring writtenEV = GetEnvironmentVariableForUser(c_evKeyName2);
+        VERIFY_ARE_EQUAL(std::wstring(c_evValueName), writtenEV);
+
+        // Update the environment variable
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName2, c_evValueName2));
+        writtenEV = GetEnvironmentVariableForUser(c_evKeyName2);
+        VERIFY_ARE_EQUAL(std::wstring(c_evValueName2), writtenEV);
+
+        // Remove the value
+        // setting the value to empty is the same as deleting the variable
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName2, L""));
+        VERIFY_ARE_EQUAL(L"", GetEnvironmentVariableForUser(c_evKeyName2));
+        VERIFY_ARE_EQUAL(ERROR_ENVVAR_NOT_FOUND, GetLastError());
+
+    }
+
+    void EnvironmentManagerCentennialTests::CentennialTestSetEnvironmentVariableForMachine()
+    {
+        EnvironmentManager environmentManager = EnvironmentManager::GetForMachine();
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName2, c_evValueName));
+
+        std::wstring writtenEV = GetEnvironmentVariableForMachine(c_evKeyName2);
+        VERIFY_ARE_EQUAL(std::wstring(c_evValueName), writtenEV);
+
+        // Update the environment variable
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName2, c_evValueName2));
+        writtenEV = GetEnvironmentVariableForMachine(c_evKeyName2);
+        VERIFY_ARE_EQUAL(std::wstring(c_evValueName2), writtenEV);
+
+        // Remove the value
+        // setting the value to empty is the same as deleting the variable
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName2, L""));
+        VERIFY_ARE_EQUAL(L"", GetEnvironmentVariableForMachine(c_evKeyName2));
+        VERIFY_ARE_EQUAL(ERROR_ENVVAR_NOT_FOUND, GetLastError());
+
     }
 }

--- a/test/EnvironmentManagerTests/EnvironmentManagerCentennialTests.h
+++ b/test/EnvironmentManagerTests/EnvironmentManagerCentennialTests.h
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #pragma once
+#include "TestSetupAndTeardownHelper.h"
 
 namespace ProjectReunionEnvironmentManagerTests
 {
@@ -10,7 +11,26 @@ namespace ProjectReunionEnvironmentManagerTests
             TEST_CLASS_PROPERTY(L"RunAs", L"{UAP,Restricted,Elevated,InteractiveUser}")
             TEST_CLASS_PROPERTY(L"UAP:Host", L"PackagedCwa")
             TEST_CLASS_PROPERTY(L"UAP:AppXManifest", L"CentennialAppxManifest.pkg.xml")
+            TEST_CLASS_PROPERTY(L"RunFixtureAs", L"Elevated")
         END_TEST_CLASS()
+
+        TEST_CLASS_SETUP(CentennialWriteEVs)
+        {
+            WriteProcessEV();
+            WriteUserEV();
+            WriteMachineEV();
+
+            return true;
+        }
+
+        TEST_CLASS_CLEANUP(CentennialRemoveEvs)
+        {
+            RemoveProcessEV();
+            RemoveUserEV();
+            RemoveMachineEV();
+
+            return true;
+        }
 
         TEST_METHOD(CentennialTestGetForProcess);
         TEST_METHOD(CentennialTestGetForUser);
@@ -18,6 +38,12 @@ namespace ProjectReunionEnvironmentManagerTests
         TEST_METHOD(CentennialTestGetEnvironmentVariablesForProcess);
         TEST_METHOD(CentennialTestGetEnvironmentVariablesForUser);
         TEST_METHOD(CentennialTestGetEnvironmentVariablesForMachine);
+        TEST_METHOD(CentennialTestGetEnvironmentVariableForProcess);
+        TEST_METHOD(CentennialTestGetEnvironmentVariableForUser);
+        TEST_METHOD(CentennialTestGetEnvironmentVariableForMachine);
+        TEST_METHOD(CentennialTestSetEnvironmentVariableForProcess);
+        TEST_METHOD(CentennialTestSetEnvironmentVariableForUser);
+        TEST_METHOD(CentennialTestSetEnvironmentVariableForMachine);
     };
 
 }

--- a/test/EnvironmentManagerTests/EnvironmentManagerTests.vcxproj
+++ b/test/EnvironmentManagerTests/EnvironmentManagerTests.vcxproj
@@ -288,12 +288,15 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="ChangeTrackerHelper.h" />
     <ClInclude Include="EnvironmentManagerCentennialTests.h" />
     <ClInclude Include="EnvironmentManagerUWPTests.h" />
     <ClInclude Include="EnvironmentManagerWin32Tests.h" />
     <ClInclude Include="framework.h" />
     <ClInclude Include="EnvironmentVariableHelper.h" />
     <ClInclude Include="pch.h" />
+    <ClInclude Include="TestCommon.h" />
+    <ClInclude Include="TestSetupAndTeardownHelper.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="EnvironmentManagerCentennialTests.cpp" />

--- a/test/EnvironmentManagerTests/EnvironmentManagerTests.vcxproj.filters
+++ b/test/EnvironmentManagerTests/EnvironmentManagerTests.vcxproj.filters
@@ -33,6 +33,15 @@
     <ClInclude Include="EnvironmentVariableHelper.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="TestSetupAndTeardownHelper.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="TestCommon.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ChangeTrackerHelper.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">

--- a/test/EnvironmentManagerTests/EnvironmentManagerUWPTests.cpp
+++ b/test/EnvironmentManagerTests/EnvironmentManagerUWPTests.cpp
@@ -4,6 +4,7 @@
 #include "pch.h"
 #include "EnvironmentManagerUWPTests.h"
 #include "EnvironmentVariableHelper.h"
+#include "TestSetupAndTeardownHelper.h"
 
 using namespace winrt::Microsoft::ProjectReunion;
 
@@ -56,5 +57,62 @@ namespace ProjectReunionEnvironmentManagerTests
         EnvironmentVariables environmentVariablesFromWinRTAPI = environmentmanager.GetEnvironmentVariables();
 
         CompareIMapViews(environmentVariablesFromWinRTAPI, environmentVariablesFromWindowsAPI);
+    }
+
+    void EnvironmentManagerUWPTests::UWPTestGetEnvironmentVariableForProcess()
+    {
+        EnvironmentManager environmentManager = EnvironmentManager::GetForProcess();
+        winrt::hstring environmentValue = environmentManager.GetEnvironmentVariable(c_evKeyName);
+
+        VERIFY_ARE_EQUAL(std::wstring(c_evValueName), environmentValue);
+    }
+
+    void EnvironmentManagerUWPTests::UWPTestGetEnvironmentVariableForUser()
+    {
+        EnvironmentManager environmentManager = EnvironmentManager::GetForUser();
+        winrt::hstring environmentValue = environmentManager.GetEnvironmentVariable(c_evKeyName);
+
+        VERIFY_ARE_EQUAL(std::wstring(c_evValueName), environmentValue);
+    }
+
+    void EnvironmentManagerUWPTests::UWPTestGetEnvironmentVariableForMachine()
+    {
+        EnvironmentManager environmentManager = EnvironmentManager::GetForUser();
+        winrt::hstring environmentValue = environmentManager.GetEnvironmentVariable(c_evKeyName);
+
+        VERIFY_ARE_EQUAL(std::wstring(c_evValueName), environmentValue);
+    }
+
+    void EnvironmentManagerUWPTests::UWPTestSetEnvironmentVariableForProcess()
+    {
+        EnvironmentManager environmentManager = EnvironmentManager::GetForProcess();
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName2, c_evValueName));
+
+        std::wstring writtenEV = GetEnvironmentVariableForProcess(c_evKeyName2);
+        VERIFY_ARE_EQUAL(std::wstring(c_evValueName), writtenEV);
+
+        // Update the environment variable
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName2, c_evValueName2));
+        writtenEV = GetEnvironmentVariableForProcess(c_evKeyName2);
+        VERIFY_ARE_EQUAL(std::wstring(c_evValueName2), writtenEV);
+
+
+        // Remove the value
+        // setting the value to empty is the same as deleting the variable
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName2, L""));
+        VERIFY_ARE_EQUAL(0, ::GetEnvironmentVariable(c_evKeyName2, nullptr, 0));
+        VERIFY_ARE_EQUAL(ERROR_ENVVAR_NOT_FOUND, GetLastError());
+    }
+
+    void EnvironmentManagerUWPTests::UWPTestSetEnvironmentVariableForUser()
+    {
+        EnvironmentManager environmentMananger = EnvironmentManager::GetForUser();
+        VERIFY_THROWS(environmentMananger.SetEnvironmentVariable(c_evKeyName, c_evValueName), winrt::hresult_access_denied);
+    }
+
+    void EnvironmentManagerUWPTests::UWPTestSetEnvironmentVariableForMachine()
+    {
+        EnvironmentManager environmentMananger = EnvironmentManager::GetForMachine();
+        VERIFY_THROWS(environmentMananger.SetEnvironmentVariable(c_evKeyName, c_evValueName), winrt::hresult_access_denied);
     }
 }

--- a/test/EnvironmentManagerTests/EnvironmentManagerUWPTests.h
+++ b/test/EnvironmentManagerTests/EnvironmentManagerUWPTests.h
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #pragma once
+#include "TestSetupAndTeardownHelper.h"
 
 namespace ProjectReunionEnvironmentManagerTests
 {
@@ -9,7 +10,26 @@ namespace ProjectReunionEnvironmentManagerTests
         BEGIN_TEST_CLASS(EnvironmentManagerUWPTests)
             TEST_CLASS_PROPERTY(L"RunAs", L"{UAP,Restricted}")
             TEST_CLASS_PROPERTY(L"UAP:AppXManifest", L"AppxManifest.pkg.xml")
+            TEST_CLASS_PROPERTY(L"RunFixtureAs", L"Elevated")
         END_TEST_CLASS()
+
+        TEST_CLASS_SETUP(UWPWriteEVs)
+        {
+            WriteProcessEV();
+            WriteUserEV();
+            WriteMachineEV();
+
+            return true;
+        }
+
+        TEST_CLASS_CLEANUP(UWPRemoveEvs)
+        {
+            RemoveProcessEV();
+            RemoveUserEV();
+            RemoveMachineEV();
+
+            return true;
+        }
 
         TEST_METHOD(UWPTestGetForProcess);
         TEST_METHOD(UWPTestGetForUser);
@@ -17,5 +37,11 @@ namespace ProjectReunionEnvironmentManagerTests
         TEST_METHOD(UWPTestGetEnvironmentVariablesForProcess);
         TEST_METHOD(UWPTestGetEnvironmentVariablesForUser);
         TEST_METHOD(UWPTestGetEnvironmentVariablesForMachine);
+        TEST_METHOD(UWPTestGetEnvironmentVariableForProcess);
+        TEST_METHOD(UWPTestGetEnvironmentVariableForUser);
+        TEST_METHOD(UWPTestGetEnvironmentVariableForMachine);
+        TEST_METHOD(UWPTestSetEnvironmentVariableForProcess);
+        TEST_METHOD(UWPTestSetEnvironmentVariableForUser);
+        TEST_METHOD(UWPTestSetEnvironmentVariableForMachine);
     };
 }

--- a/test/EnvironmentManagerTests/EnvironmentManagerWin32Tests.cpp
+++ b/test/EnvironmentManagerTests/EnvironmentManagerWin32Tests.cpp
@@ -57,4 +57,91 @@ namespace ProjectReunionEnvironmentManagerTests
 
         CompareIMapViews(environmentVariablesFromWinRTAPI, environmentVariablesFromWindowsAPI);
     }
+
+    void EnvironmentManagerWin32Tests::TestGetEnvironmentVariableForProcess()
+    {
+        EnvironmentManager environmentManager = EnvironmentManager::GetForProcess();
+        winrt::hstring environmentValue = environmentManager.GetEnvironmentVariable(c_evKeyName);
+
+        VERIFY_ARE_EQUAL(std::wstring(c_evValueName), environmentValue);
+    }
+
+    void EnvironmentManagerWin32Tests::TestGetEnvironmentVariableForUser()
+    {
+        EnvironmentManager environmentManager = EnvironmentManager::GetForUser();
+        winrt::hstring environmentValue = environmentManager.GetEnvironmentVariable(c_evKeyName);
+
+        VERIFY_ARE_EQUAL(std::wstring(c_evValueName), environmentValue);
+    }
+
+    void EnvironmentManagerWin32Tests::TestGetEnvironmentVariableForMachine()
+    {
+        EnvironmentManager environmentManager = EnvironmentManager::GetForMachine();
+        winrt::hstring environmentValue = environmentManager.GetEnvironmentVariable(c_evKeyName);
+
+        VERIFY_ARE_EQUAL(std::wstring(c_evValueName), environmentValue);
+    }
+
+    void EnvironmentManagerWin32Tests::TestSetEnvironmentVariableForProcess()
+    {
+        EnvironmentManager environmentManager = EnvironmentManager::GetForProcess();
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName2, c_evValueName));
+
+        std::wstring writtenEV = GetEnvironmentVariableForProcess(c_evKeyName2);
+        VERIFY_ARE_EQUAL(std::wstring(c_evValueName), writtenEV);
+
+        // Update the environment variable
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName2, c_evValueName2));
+        writtenEV = GetEnvironmentVariableForProcess(c_evKeyName2);
+        VERIFY_ARE_EQUAL(std::wstring(c_evValueName2), writtenEV);
+
+
+        // Remove the value
+        // setting the value to empty is the same as deleting the variable
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName2, L""));
+        VERIFY_ARE_EQUAL(0, ::GetEnvironmentVariable(c_evKeyName2, nullptr, 0));
+        VERIFY_ARE_EQUAL(ERROR_ENVVAR_NOT_FOUND, GetLastError());
+    }
+
+    void EnvironmentManagerWin32Tests::TestSetEnvironmentVariableForUser()
+    {
+        EnvironmentManager environmentManager = EnvironmentManager::GetForUser();
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName2, c_evValueName));
+
+        std::wstring writtenEV = GetEnvironmentVariableForUser(c_evKeyName2);
+        VERIFY_ARE_EQUAL(std::wstring(c_evValueName), writtenEV);
+
+        // Update the environment variable
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName2, c_evValueName2));
+        writtenEV = GetEnvironmentVariableForUser(c_evKeyName2);
+        VERIFY_ARE_EQUAL(std::wstring(c_evValueName2), writtenEV);
+
+
+        // Remove the value
+        // setting the value to empty is the same as deleting the variable
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName2, L""));
+        VERIFY_ARE_EQUAL(L"", GetEnvironmentVariableForUser(c_evKeyName2));
+        VERIFY_ARE_EQUAL(ERROR_ENVVAR_NOT_FOUND, GetLastError());
+    }
+
+    void EnvironmentManagerWin32Tests::TestSetEnvironmentVariableForMachine()
+    {
+        EnvironmentManager environmentManager = EnvironmentManager::GetForMachine();
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName2, c_evValueName));
+
+        std::wstring writtenEV = GetEnvironmentVariableForMachine(c_evKeyName2);
+        VERIFY_ARE_EQUAL(std::wstring(c_evValueName), writtenEV);
+
+        // Update the environment variable
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName2, c_evValueName2));
+        writtenEV = GetEnvironmentVariableForMachine(c_evKeyName2);
+        VERIFY_ARE_EQUAL(std::wstring(c_evValueName2), writtenEV);
+
+
+        // Remove the value
+        // setting the value to empty is the same as deleting the variable
+        VERIFY_NO_THROW(environmentManager.SetEnvironmentVariable(c_evKeyName2, L""));
+        VERIFY_ARE_EQUAL(L"", GetEnvironmentVariableForMachine(c_evKeyName2));
+        VERIFY_ARE_EQUAL(ERROR_ENVVAR_NOT_FOUND, GetLastError());
+    }
 }

--- a/test/EnvironmentManagerTests/EnvironmentManagerWin32Tests.h
+++ b/test/EnvironmentManagerTests/EnvironmentManagerWin32Tests.h
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #pragma once
+#include "TestSetupAndTeardownHelper.h"
 
 namespace ProjectReunionEnvironmentManagerTests
 {
@@ -10,7 +11,26 @@ namespace ProjectReunionEnvironmentManagerTests
             TEST_CLASS_PROPERTY(L"ActivationContext", L"EnvironmentManagerTests.dll.manifest")
             TEST_CLASS_PROPERTY(L"ThreadingModel", L"MTA")
             TEST_CLASS_PROPERTY(L"RunAs", L"{Restricted,Elevated,InteractiveUser}")
-        END_TEST_CLASS()
+            TEST_CLASS_PROPERTY(L"RunFixtureAs", L"Elevated")
+       END_TEST_CLASS()
+
+       TEST_CLASS_SETUP(WriteEVs)
+       {
+           WriteProcessEV();
+           WriteUserEV();
+           WriteMachineEV();
+
+           return true;
+       }
+
+       TEST_CLASS_CLEANUP(RemoveEvs)
+       {
+           RemoveProcessEV();
+           RemoveUserEV();
+           RemoveMachineEV();
+
+           return true;
+       }
 
         TEST_METHOD(TestGetForProcess);
         TEST_METHOD(TestGetForUser);
@@ -18,5 +38,11 @@ namespace ProjectReunionEnvironmentManagerTests
         TEST_METHOD(TestGetEnvironmentVariablesForProcess);
         TEST_METHOD(TestGetEnvironmentVariablesForUser);
         TEST_METHOD(TestGetEnvironmentVariablesForMachine);
+        TEST_METHOD(TestGetEnvironmentVariableForProcess);
+        TEST_METHOD(TestGetEnvironmentVariableForUser);
+        TEST_METHOD(TestGetEnvironmentVariableForMachine);
+        TEST_METHOD(TestSetEnvironmentVariableForProcess);
+        TEST_METHOD(TestSetEnvironmentVariableForUser);
+        TEST_METHOD(TestSetEnvironmentVariableForMachine);
     };
 }

--- a/test/EnvironmentManagerTests/TestCommon.h
+++ b/test/EnvironmentManagerTests/TestCommon.h
@@ -1,0 +1,25 @@
+﻿#pragma once
+#include "pch.h"
+
+inline constexpr PCWSTR c_userEvRegLocation = L"Environment";
+inline constexpr PCWSTR c_machineEvRegLocation = L"SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment";
+
+inline constexpr PCWSTR c_evKeyName = L"TestKey";
+inline constexpr PCWSTR c_evValueName = L"TestValue";
+
+inline constexpr PCWSTR c_evKeyName2 = L"TestKey2";
+inline constexpr PCWSTR c_evValueName2 = L"TestValue2";
+
+inline const std::wstring c_trackerKeyLocationForUser()
+{
+    return std::wstring(L"EnvironmentVariables\\Microsoft.Process.Environment.Centennial.Tests_1.0.0.0_neutral_en-us_8wekyb3d8bbwe\\")
+        .append(c_evKeyName2)
+        .append(std::wstring(L"\\User"));
+}
+
+inline const std::wstring c_trackerKeyLocationForMachine()
+{
+    return std::wstring(L"EnvironmentVariables\\Microsoft.Process.Environment.Centennial.Tests_1.0.0.0_neutral_en-us_8wekyb3d8bbwe\\")
+        .append(c_evKeyName2)
+        .append(std::wstring(L"\\Machine"));
+}

--- a/test/EnvironmentManagerTests/TestSetupAndTeardownHelper.h
+++ b/test/EnvironmentManagerTests/TestSetupAndTeardownHelper.h
@@ -1,0 +1,40 @@
+﻿#pragma once
+#include "TestCommon.h"
+
+inline void WriteProcessEV()
+{
+    SetEnvironmentVariable(c_evKeyName, c_evValueName);
+}
+
+inline void RemoveProcessEV()
+{
+    SetEnvironmentVariable(c_evKeyName, nullptr);
+}
+
+inline void WriteUserEV()
+{
+    wil::unique_hkey userEnvironmentVariablesHKey{};
+    VERIFY_WIN32_SUCCEEDED(RegOpenKeyEx(HKEY_CURRENT_USER, c_userEvRegLocation, 0, KEY_WRITE, userEnvironmentVariablesHKey.addressof()));
+    VERIFY_WIN32_SUCCEEDED(RegSetValueExW(userEnvironmentVariablesHKey.get(), c_evKeyName, 0, REG_SZ, (LPBYTE)c_evValueName, static_cast<DWORD>(wcslen(c_evValueName) * sizeof(wchar_t))));
+}
+
+inline void RemoveUserEV()
+{
+    wil::unique_hkey userEnvironmentVariablesHKey{};
+    VERIFY_WIN32_SUCCEEDED(RegOpenKeyEx(HKEY_CURRENT_USER, c_userEvRegLocation, 0, KEY_WRITE, userEnvironmentVariablesHKey.addressof()));
+    VERIFY_WIN32_SUCCEEDED(RegDeleteValueW(userEnvironmentVariablesHKey.get(), c_evKeyName));
+}
+
+inline void WriteMachineEV()
+{
+    wil::unique_hkey machineEnvironmentVariablesHKey{};
+    VERIFY_WIN32_SUCCEEDED(RegOpenKeyEx(HKEY_CURRENT_USER, c_machineEvRegLocation, 0, KEY_WRITE, machineEnvironmentVariablesHKey.addressof()));
+    VERIFY_WIN32_SUCCEEDED(RegSetValueExW(machineEnvironmentVariablesHKey.get(), c_evKeyName, 0, REG_SZ, (LPBYTE)c_evValueName, static_cast<DWORD>(wcslen(c_evValueName) * sizeof(wchar_t))));
+}
+
+inline void RemoveMachineEV()
+{
+    wil::unique_hkey machineEnvironmentVariablesHKey{};
+    VERIFY_WIN32_SUCCEEDED(RegOpenKeyEx(HKEY_CURRENT_USER, c_machineEvRegLocation, 0, KEY_WRITE, machineEnvironmentVariablesHKey.addressof()));
+    VERIFY_WIN32_SUCCEEDED(RegDeleteValueW(machineEnvironmentVariablesHKey.get(), c_evKeyName));
+}


### PR DESCRIPTION
This change includes the implementation and testing of
1. GetEnvironmentVariable
2. SetEnvironmentVariable
3. ChangeTracking

The Change Tracker allows a centennial app to track any environment variable changes in the user and machine scope.  These changes will be removed when the app is uninstalled.

A non-Centennial app can still use this API to set an environment variable however.