### PR TITLE
User/benkuhn/add vsix patch option

### DIFF
--- a/build/ProjectReunion-Create-VSIX.yml
+++ b/build/ProjectReunion-Create-VSIX.yml
@@ -14,6 +14,11 @@ parameters:
   - name: "releaseBuild"
     type: boolean
     default: True
+  - name: "OptionalVSIXVersion"
+    # if blank, the project template will select the version matching the Project Reunion
+    # nuget. If provided, it should be a 4-part dotted version ('1.2.3.4')
+    type: string
+    default: ''
 
 jobs:
 
@@ -22,7 +27,7 @@ jobs:
     vmImage: 'windows-2019'
 
   steps:
-  - task: NuGetAuthenticate@0
+    - task: NuGetAuthenticate@0
     inputs:
       nuGetServiceConnections: Internal-ReleaseSigned
 
@@ -32,7 +37,7 @@ jobs:
       solution: dev\VSIX\ProjectReunion.Extension.sln
       platform: 'Any CPU'
       configuration: '$(buildConfiguration)'
-      msBuildArgs: '/t:restore /p:ReunionVersion="${{ parameters.ReunionVersion }}" /p:ReunionFoundationVersion="${{ parameters.ReunionFoundationVersion }}" /p:ReunionDWriteVersion="${{ parameters.ReunionDWriteVersion }}" /p:ReunionWinUIVersion="${{ parameters.ReunionWinUIVersion }}" '
+      msBuildArgs: '/t:restore /p:VSIXVersion="${{ parameters.OptionalVSIXVersion }}" /p:ReunionVersion="${{ parameters.ReunionVersion }}" /p:ReunionFoundationVersion="${{ parameters.ReunionFoundationVersion }}" /p:ReunionDWriteVersion="${{ parameters.ReunionDWriteVersion }}" /p:ReunionWinUIVersion="${{ parameters.ReunionWinUIVersion }}" '
 
   - task: VSBuild@1
     displayName: 'Build ProjectReunion.Extension.sln'
@@ -40,7 +45,7 @@ jobs:
       solution: dev\VSIX\ProjectReunion.Extension.sln
       platform: 'Any CPU'
       configuration: '$(buildConfiguration)'
-      msBuildArgs: '/p:ReunionVersion="${{ parameters.ReunionVersion }}" /p:ReunionFoundationVersion="${{ parameters.ReunionFoundationVersion }}" /p:ReunionDWriteVersion="${{ parameters.ReunionDWriteVersion }}" /p:ReunionWinUIVersion="${{ parameters.ReunionWinUIVersion }}" '
+      msBuildArgs: '/p:VSIXVersion="${{ parameters.OptionalVSIXVersion }}" /p:ReunionVersion="${{ parameters.ReunionVersion }}" /p:ReunionFoundationVersion="${{ parameters.ReunionFoundationVersion }}" /p:ReunionDWriteVersion="${{ parameters.ReunionDWriteVersion }}" /p:ReunionWinUIVersion="${{ parameters.ReunionWinUIVersion }}" '
 
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Governance Detection'

--- a/build/ProjectReunion-Create-VSIX.yml
+++ b/build/ProjectReunion-Create-VSIX.yml
@@ -27,7 +27,7 @@ jobs:
     vmImage: 'windows-2019'
 
   steps:
-    - task: NuGetAuthenticate@0
+  - task: NuGetAuthenticate@0
     inputs:
       nuGetServiceConnections: Internal-ReleaseSigned
 

--- a/build/ProjectReunion-Create-VSIX.yml
+++ b/build/ProjectReunion-Create-VSIX.yml
@@ -31,13 +31,18 @@ jobs:
     inputs:
       nuGetServiceConnections: Internal-ReleaseSigned
 
+  - script: echo '##vso[task.setvariable variable=VersionList]/p:ReunionVersion="${{ parameters.ReunionVersion }}" /p:ReunionFoundationVersion="${{ parameters.ReunionFoundationVersion }}" /p:ReunionDWriteVersion="${{ parameters.ReunionDWriteVersion }}" /p:ReunionWinUIVersion="${{ parameters.ReunionWinUIVersion }}"'
+
+  - ${{ if not(eq(parameters.OptionalVSIXVersion, 'default')) }}:
+    - script: echo '##vso[task.setvariable variable=VersionList]/p:VSIXVersion="${{ parameters.OptionalVSIXVersion }}" ${{ variables.VersionList }}'
+
   - task: VSBuild@1
     displayName: 'Restore ProjectReunion.Extension.sln'
     inputs:
       solution: dev\VSIX\ProjectReunion.Extension.sln
       platform: 'Any CPU'
       configuration: '$(buildConfiguration)'
-      msBuildArgs: '/t:restore /p:VSIXVersion="${{ parameters.OptionalVSIXVersion }}" /p:ReunionVersion="${{ parameters.ReunionVersion }}" /p:ReunionFoundationVersion="${{ parameters.ReunionFoundationVersion }}" /p:ReunionDWriteVersion="${{ parameters.ReunionDWriteVersion }}" /p:ReunionWinUIVersion="${{ parameters.ReunionWinUIVersion }}" '
+      msBuildArgs: '/t:restore ${{ variables.VersionList }}'
 
   - task: VSBuild@1
     displayName: 'Build ProjectReunion.Extension.sln'
@@ -45,7 +50,7 @@ jobs:
       solution: dev\VSIX\ProjectReunion.Extension.sln
       platform: 'Any CPU'
       configuration: '$(buildConfiguration)'
-      msBuildArgs: '/p:VSIXVersion="${{ parameters.OptionalVSIXVersion }}" /p:ReunionVersion="${{ parameters.ReunionVersion }}" /p:ReunionFoundationVersion="${{ parameters.ReunionFoundationVersion }}" /p:ReunionDWriteVersion="${{ parameters.ReunionDWriteVersion }}" /p:ReunionWinUIVersion="${{ parameters.ReunionWinUIVersion }}" '
+      msBuildArgs: '${{ variables.VersionList }}'
 
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Governance Detection'

--- a/build/ProjectReunion-Create-VSIX.yml
+++ b/build/ProjectReunion-Create-VSIX.yml
@@ -36,6 +36,8 @@ jobs:
   - ${{ if not(eq(parameters.OptionalVSIXVersion, 'default')) }}:
     - script: echo '##vso[task.setvariable variable=VersionList]/p:VSIXVersion="${{ parameters.OptionalVSIXVersion }}" ${{ variables.VersionList }}'
 
+  - script: echo '${{ variables.VersionList }}'
+
   - task: VSBuild@1
     displayName: 'Restore ProjectReunion.Extension.sln'
     inputs:

--- a/build/ProjectReunion-Create-VSIX.yml
+++ b/build/ProjectReunion-Create-VSIX.yml
@@ -31,20 +31,13 @@ jobs:
     inputs:
       nuGetServiceConnections: Internal-ReleaseSigned
 
-  - script: echo '##vso[task.setvariable variable=VersionList]/p:ReunionVersion="${{ parameters.ReunionVersion }}" /p:ReunionFoundationVersion="${{ parameters.ReunionFoundationVersion }}" /p:ReunionDWriteVersion="${{ parameters.ReunionDWriteVersion }}" /p:ReunionWinUIVersion="${{ parameters.ReunionWinUIVersion }}"'
-
-  - ${{ if not(eq(parameters.OptionalVSIXVersion, 'default')) }}:
-    - script: echo '##vso[task.setvariable variable=VersionList]/p:VSIXVersion="${{ parameters.OptionalVSIXVersion }}" $(VersionList)'
-
-  - script: echo '$(VersionList)'
-
   - task: VSBuild@1
     displayName: 'Restore ProjectReunion.Extension.sln'
     inputs:
       solution: dev\VSIX\ProjectReunion.Extension.sln
       platform: 'Any CPU'
       configuration: '$(buildConfiguration)'
-      msBuildArgs: '/t:restore $(VersionList)'
+      msBuildArgs: '/t:restore /p:OptionalVSIXVersion="${{ parameters.OptionalVSIXVersion }}" /p:ReunionVersion="${{ parameters.ReunionVersion }}" /p:ReunionFoundationVersion="${{ parameters.ReunionFoundationVersion }}" /p:ReunionDWriteVersion="${{ parameters.ReunionDWriteVersion }}" /p:ReunionWinUIVersion="${{ parameters.ReunionWinUIVersion }}"'
 
   - task: VSBuild@1
     displayName: 'Build ProjectReunion.Extension.sln'
@@ -52,7 +45,7 @@ jobs:
       solution: dev\VSIX\ProjectReunion.Extension.sln
       platform: 'Any CPU'
       configuration: '$(buildConfiguration)'
-      msBuildArgs: '$(VersionList)'
+      msBuildArgs: '/p:OptionalVSIXVersion="${{ parameters.OptionalVSIXVersion }}" /p:ReunionVersion="${{ parameters.ReunionVersion }}" /p:ReunionFoundationVersion="${{ parameters.ReunionFoundationVersion }}" /p:ReunionDWriteVersion="${{ parameters.ReunionDWriteVersion }}" /p:ReunionWinUIVersion="${{ parameters.ReunionWinUIVersion }}"'
 
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Governance Detection'

--- a/build/ProjectReunion-Create-VSIX.yml
+++ b/build/ProjectReunion-Create-VSIX.yml
@@ -31,15 +31,10 @@ jobs:
     inputs:
       nuGetServiceConnections: Internal-ReleaseSigned
 
-  - script: |
-      echo 'Configuring package versions. "${{ parameters.ReunionVersion }}"'
-      echo '##vso[task.setvariable variable=VersionList]/p:ReunionVersion="${{ parameters.ReunionVersion }}" /p:ReunionFoundationVersion="${{ parameters.ReunionFoundationVersion }}" /p:ReunionDWriteVersion="${{ parameters.ReunionDWriteVersion }}" /p:ReunionWinUIVersion="${{ parameters.ReunionWinUIVersion }}"'
+  - script: echo '##vso[task.setvariable variable=VersionList]/p:ReunionVersion="${{ parameters.ReunionVersion }}" /p:ReunionFoundationVersion="${{ parameters.ReunionFoundationVersion }}" /p:ReunionDWriteVersion="${{ parameters.ReunionDWriteVersion }}" /p:ReunionWinUIVersion="${{ parameters.ReunionWinUIVersion }}"'
 
   - ${{ if not(eq(parameters.OptionalVSIXVersion, 'default')) }}:
-    - script: |
-        echo 'Adding override version: "${{ parameters.OptionalVSIXVersion }}"'
-        echo ' To existing versions: "${{ variables.VersionList }}"'
-        echo '##vso[task.setvariable variable=VersionList]/p:VSIXVersion="${{ parameters.OptionalVSIXVersion }}" ${{ variables.VersionList }}'
+    - script: echo '##vso[task.setvariable variable=VersionList]/p:VSIXVersion="${{ parameters.OptionalVSIXVersion }}" ${{ variables.VersionList }}'
 
   - task: VSBuild@1
     displayName: 'Restore ProjectReunion.Extension.sln'

--- a/build/ProjectReunion-Create-VSIX.yml
+++ b/build/ProjectReunion-Create-VSIX.yml
@@ -34,9 +34,9 @@ jobs:
   - script: echo '##vso[task.setvariable variable=VersionList]/p:ReunionVersion="${{ parameters.ReunionVersion }}" /p:ReunionFoundationVersion="${{ parameters.ReunionFoundationVersion }}" /p:ReunionDWriteVersion="${{ parameters.ReunionDWriteVersion }}" /p:ReunionWinUIVersion="${{ parameters.ReunionWinUIVersion }}"'
 
   - ${{ if not(eq(parameters.OptionalVSIXVersion, 'default')) }}:
-    - script: echo '##vso[task.setvariable variable=VersionList]/p:VSIXVersion="${{ parameters.OptionalVSIXVersion }}" ${{ variables.VersionList }}'
+    - script: echo '##vso[task.setvariable variable=VersionList]/p:VSIXVersion="${{ parameters.OptionalVSIXVersion }}" $(VersionList)'
 
-  - script: echo '${{ variables.VersionList }}'
+  - script: echo '$(VersionList)'
 
   - task: VSBuild@1
     displayName: 'Restore ProjectReunion.Extension.sln'
@@ -44,7 +44,7 @@ jobs:
       solution: dev\VSIX\ProjectReunion.Extension.sln
       platform: 'Any CPU'
       configuration: '$(buildConfiguration)'
-      msBuildArgs: '/t:restore ${{ variables.VersionList }}'
+      msBuildArgs: '/t:restore $(VersionList)'
 
   - task: VSBuild@1
     displayName: 'Build ProjectReunion.Extension.sln'
@@ -52,7 +52,7 @@ jobs:
       solution: dev\VSIX\ProjectReunion.Extension.sln
       platform: 'Any CPU'
       configuration: '$(buildConfiguration)'
-      msBuildArgs: '${{ variables.VersionList }}'
+      msBuildArgs: '$(VersionList)'
 
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Governance Detection'

--- a/build/ProjectReunion-Create-VSIX.yml
+++ b/build/ProjectReunion-Create-VSIX.yml
@@ -18,7 +18,7 @@ parameters:
     # if blank, the project template will select the version matching the Project Reunion
     # nuget. If provided, it should be a 4-part dotted version ('1.2.3.4')
     type: string
-    default: ''
+    default: 'default'
 
 jobs:
 

--- a/build/ProjectReunion-Create-VSIX.yml
+++ b/build/ProjectReunion-Create-VSIX.yml
@@ -31,10 +31,14 @@ jobs:
     inputs:
       nuGetServiceConnections: Internal-ReleaseSigned
 
-  - script: echo '##vso[task.setvariable variable=VersionList]/p:ReunionVersion="${{ parameters.ReunionVersion }}" /p:ReunionFoundationVersion="${{ parameters.ReunionFoundationVersion }}" /p:ReunionDWriteVersion="${{ parameters.ReunionDWriteVersion }}" /p:ReunionWinUIVersion="${{ parameters.ReunionWinUIVersion }}"'
+  - script: |
+      echo 'Configuring package versions. "${{ parameters.ReunionVersion }}"'
+      echo '##vso[task.setvariable variable=VersionList]/p:ReunionVersion="${{ parameters.ReunionVersion }}" /p:ReunionFoundationVersion="${{ parameters.ReunionFoundationVersion }}" /p:ReunionDWriteVersion="${{ parameters.ReunionDWriteVersion }}" /p:ReunionWinUIVersion="${{ parameters.ReunionWinUIVersion }}"'
 
   - ${{ if not(eq(parameters.OptionalVSIXVersion, 'default')) }}:
-    - script: echo '##vso[task.setvariable variable=VersionList]/p:VSIXVersion="${{ parameters.OptionalVSIXVersion }}" ${{ variables.VersionList }}'
+    - script: |
+        echo 'Adding override version: "${{ parameters.OptionalVSIXVersion }}"'
+        echo '##vso[task.setvariable variable=VersionList]/p:VSIXVersion="${{ parameters.OptionalVSIXVersion }}" ${{ variables.VersionList }}'
 
   - task: VSBuild@1
     displayName: 'Restore ProjectReunion.Extension.sln'

--- a/build/ProjectReunion-Create-VSIX.yml
+++ b/build/ProjectReunion-Create-VSIX.yml
@@ -38,6 +38,7 @@ jobs:
   - ${{ if not(eq(parameters.OptionalVSIXVersion, 'default')) }}:
     - script: |
         echo 'Adding override version: "${{ parameters.OptionalVSIXVersion }}"'
+        echo ' To existing versions: "${{ variables.VersionList }}"'
         echo '##vso[task.setvariable variable=VersionList]/p:VSIXVersion="${{ parameters.OptionalVSIXVersion }}" ${{ variables.VersionList }}'
 
   - task: VSBuild@1

--- a/dev/VSIX/Extension/ProjectReunion.Extension.csproj
+++ b/dev/VSIX/Extension/ProjectReunion.Extension.csproj
@@ -205,7 +205,7 @@
   -->
   <PropertyGroup Condition="'$(VSIXVersion)' == ''">
     <TimeSpan>$([System.Math]::Floor($([System.DateTime]::UtcNow.Subtract($([System.DateTime]::Parse('2020-01-01T00:00Z'))).TotalSeconds)))</TimeSpan>
-    <VSIXVersion>$(ReunionVSIXVersion)</VSIXVersion>
+    <VSIXVersion>$(ReunionVersion)</VSIXVersion>
     <VSIXVersion Condition="$(VSIXVersion.Contains(&quot;-&quot;))">$(VSIXVersion.Substring(0, $(VSIXVersion.IndexOf("-")))).$(TimeSpan)</VSIXVersion>
   </PropertyGroup>
   <Target Name="GetVSIXVersion" Outputs="$(VSIXVersion)" />

--- a/dev/VSIX/Extension/ProjectReunion.Extension.csproj
+++ b/dev/VSIX/Extension/ProjectReunion.Extension.csproj
@@ -201,11 +201,11 @@
     † Note: Yes, this introduces a Year 2088 problem for the locally-built VSIX because the
     final component of the version number can wrap around after 68 years. No, this is not
     a concern because it seems unlikely that we'll go 68 years without resetting the clock
-    by increasing the WinUI version number.
+    by increasing the Project Reunion version number.
   -->
   <PropertyGroup Condition="'$(VSIXVersion)' == ''">
     <TimeSpan>$([System.Math]::Floor($([System.DateTime]::UtcNow.Subtract($([System.DateTime]::Parse('2020-01-01T00:00Z'))).TotalSeconds)))</TimeSpan>
-    <VSIXVersion>$(ReunionVersion)</VSIXVersion>
+    <VSIXVersion>$(ReunionVSIXVersion)</VSIXVersion>
     <VSIXVersion Condition="$(VSIXVersion.Contains(&quot;-&quot;))">$(VSIXVersion.Substring(0, $(VSIXVersion.IndexOf("-")))).$(TimeSpan)</VSIXVersion>
   </PropertyGroup>
   <Target Name="GetVSIXVersion" Outputs="$(VSIXVersion)" />

--- a/dev/VSIX/Extension/ProjectReunion.Extension.csproj
+++ b/dev/VSIX/Extension/ProjectReunion.Extension.csproj
@@ -203,6 +203,10 @@
     a concern because it seems unlikely that we'll go 68 years without resetting the clock
     by increasing the Project Reunion version number.
   -->
+  <PropertyGroup Condition="'$(VSIXVersion)' == '' AND '$(OptionalVSIXVersion)'!='default' AND '$(OptionalVSIXVersion)'!=''">
+    <!-- Optional VSIX version is provided by the pipeline definition to override package version -->
+    <VSIXVersion>$(OptionalVSIXVersion)</VSIXVersion>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(VSIXVersion)' == ''">
     <TimeSpan>$([System.Math]::Floor($([System.DateTime]::UtcNow.Subtract($([System.DateTime]::Parse('2020-01-01T00:00Z'))).TotalSeconds)))</TimeSpan>
     <VSIXVersion>$(ReunionVersion)</VSIXVersion>


### PR DESCRIPTION
Provide option for force a particular VSIX version during runs of the VSIX build pipeline. Default for local builds or pipeline builds will still use a version adapted from Project Reunion. I tried a few different ways of putting this into the YAML, and while I'm sure it's possible, in the end I found it a lot simpler to bake this into the project file instead, just passing the option through to msbuild.