### PR TITLE
Fix image not being displayed no main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 | Delight users with modern UI | Access new platform features | Backwards compatible | 
 |:--:|:--:|:--:|
-| <img src="https://docs.microsoft.com/media/illustrations/biztalk-get-started-get-started.svg" width=250 alt="Modern navigation"/><br>Powerful WinUI 3 UI | <img src="https://docs.microsoft.com/media/illustrations/biztalk-get-started-scenarios.svg" width=250 alt="Platform logo"/><br>Localization + power status + more<br> | <img src="https://docs.microsoft.com/media/illustrations/biztalk-host-integration-install-configure.svg" width=250 alt="Down-level logo"/><br>Down to Windows 10 1809 |
+| <img src="https://docs.microsoft.com/en-us/media/illustrations/biztalk-get-started-get-started.svg" width=250 alt="Modern navigation"/><br>Powerful WinUI 3 UI | <img src="https://docs.microsoft.com/media/illustrations/biztalk-get-started-scenarios.svg" width=250 alt="Platform logo"/><br>Localization + power status + more<br> | <img src="https://docs.microsoft.com/media/illustrations/biztalk-host-integration-install-configure.svg" width=250 alt="Down-level logo"/><br>Down to Windows 10 1809 |
 
 ...and more, **without having to rewrite your app!**
 


### PR DESCRIPTION
I don't know why, but the locale specific redirect wasn't working on the first image so specifying the `en-us` version as that's better than the image not displaying at all.

This is how it looked before:

![partial screenshot showing image missing](https://user-images.githubusercontent.com/189547/113445898-8e125e00-93ee-11eb-9dd4-750781f45efc.png)
