### PR TITLE
remove subfolder for Microsoft.ApplicationModel.Resources.winmd

### DIFF
--- a/dev/MRTCore/packaging/native/Microsoft.ApplicationModel.Resources.WinRt.props
+++ b/dev/MRTCore/packaging/native/Microsoft.ApplicationModel.Resources.WinRt.props
@@ -15,7 +15,7 @@
   <!-- OutputType Exe corresponds to C++. -->
   <ItemGroup Condition="'$(OutputType)' == 'Exe'">
     <Reference Include="Microsoft.ApplicationModel.Resources.winmd">
-      <HintPath>$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.ApplicationModel.Resources\Microsoft.ApplicationModel.Resources.winmd</HintPath>
+      <HintPath>$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.ApplicationModel.Resources.winmd</HintPath>
       <Implementation Condition="'$(ProjectReunionFrameworkPackage)' != 'true'">$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(_MrtCoreRuntimeIdentifier)\native\Microsoft.ApplicationModel.Resources.dll</Implementation>
       <IsWinMDFile>true</IsWinMDFile>
     </Reference>

--- a/dev/MRTCore/packaging/native/Microsoft.ApplicationModel.Resources.props
+++ b/dev/MRTCore/packaging/native/Microsoft.ApplicationModel.Resources.props
@@ -6,41 +6,5 @@
   <Import Project="$(MSBuildThisFileDirectory)..\Microsoft.ProjectReunion.Package.props" Condition="Exists('$(MSBuildThisFileDirectory)..\Microsoft.ProjectReunion.Package.props')" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.ApplicationModel.Resources.C.props" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.ApplicationModel.Resources.WinRt.props" />
-  
-  <!-- <ItemGroup>
-    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\x86\Release\Microsoft.ProjectReunion.0.5.appx">
-      <Architecture>x86</Architecture>
-      <Version>$(MicrosoftProjectReunionAppxVersion)</Version>
-      <Publisher>'CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US'</Publisher>
-    </AppxPackageRegistration>
-  </ItemGroup>
-  <ItemGroup>
-    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\x86\Release\Microsoft.ProjectReunion.0.5.appx">
-      <Architecture>Win32</Architecture>
-      <Version>$(MicrosoftProjectReunionAppxVersion)</Version>
-      <Publisher>'CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US'</Publisher>
-    </AppxPackageRegistration>
-  </ItemGroup>
-  <ItemGroup>
-    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\x64\Release\Microsoft.ProjectReunion.0.5.appx">
-      <Architecture>x64</Architecture>
-      <Version>$(MicrosoftProjectReunionAppxVersion)</Version>
-      <Publisher>'CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US'</Publisher>
-    </AppxPackageRegistration>
-  </ItemGroup>
-  <ItemGroup>
-    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\arm\Release\Microsoft.ProjectReunion.0.5.appx">
-      <Architecture>arm</Architecture>
-      <Version>$(MicrosoftProjectReunionAppxVersion)</Version>
-      <Publisher>'CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US'</Publisher>
-    </AppxPackageRegistration>
-  </ItemGroup>
-  <ItemGroup>
-    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\arm64\Release\Microsoft.ProjectReunion.0.5.appx">
-      <Architecture>arm64</Architecture>
-      <Version>$(MicrosoftProjectReunionAppxVersion)</Version>
-      <Publisher>'CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US'</Publisher>
-    </AppxPackageRegistration>
-  </ItemGroup> -->
 
 </Project>

--- a/dev/MRTCore/publish-mrt.yml
+++ b/dev/MRTCore/publish-mrt.yml
@@ -18,19 +18,13 @@ steps:
 
 # START of copying files into their final package location.
 
-# Place Microsoft.ApplicationModel.Resources.winmd in the Microsoft.ApplicationModel.Resources\
-# subfolder so that it doesn't conflict the same file in the WinUI3 feeder NuGet package during
-# the aggregation phase of the Project Reunion NuGet packages generation.
-# That conflict is the result of the WinUI3 NuGet package including MRTCore contents in it. When
-# those MRTCore files are removed from the WinUI3 NuGet package, this folder can be removed, though
-# that's not necessary.
 - task: CopyFiles@2
   displayName: 'copy winmd into uap10.0 folder'
   inputs:
     SourceFolder: '$(Build.ArtifactStagingDirectory)\mrt_raw\mrtcore_binaries\lib\anycpu'
     Contents: |
       Microsoft.ApplicationModel.Resources.winmd
-    TargetFolder: '$(Build.ArtifactStagingDirectory)\fullnuget\lib\uap10.0\Microsoft.ApplicationModel.Resources\'
+    TargetFolder: '$(Build.ArtifactStagingDirectory)\fullnuget\lib\uap10.0\'
     flattenFolders: true
 
 # Needed so that the NuGet package can be installed in a win32 app. It avoids this error: "You are trying to


### PR DESCRIPTION
As MRTCore is no longer part of WinUI package, there is no need to hide the M.AM.R.winmd in a subfolder.