### PR TITLE
User/benkuhn/vsix version

### DIFF
--- a/build/ProjectReunion-Create-VSIX.yml
+++ b/build/ProjectReunion-Create-VSIX.yml
@@ -14,6 +14,11 @@ parameters:
   - name: "releaseBuild"
     type: boolean
     default: True
+  - name: "OptionalVSIXVersion"
+    # if blank, the project template will select the version matching the Project Reunion
+    # nuget. If provided, it should be a 4-part dotted version ('1.2.3.4')
+    type: string
+    default: 'default'
 
 jobs:
 
@@ -32,7 +37,7 @@ jobs:
       solution: dev\VSIX\ProjectReunion.Extension.sln
       platform: 'Any CPU'
       configuration: '$(buildConfiguration)'
-      msBuildArgs: '/t:restore /p:ReunionVersion="${{ parameters.ReunionVersion }}" /p:ReunionFoundationVersion="${{ parameters.ReunionFoundationVersion }}" /p:ReunionDWriteVersion="${{ parameters.ReunionDWriteVersion }}" /p:ReunionWinUIVersion="${{ parameters.ReunionWinUIVersion }}" '
+      msBuildArgs: '/t:restore /p:OptionalVSIXVersion="${{ parameters.OptionalVSIXVersion }}" /p:ReunionVersion="${{ parameters.ReunionVersion }}" /p:ReunionFoundationVersion="${{ parameters.ReunionFoundationVersion }}" /p:ReunionDWriteVersion="${{ parameters.ReunionDWriteVersion }}" /p:ReunionWinUIVersion="${{ parameters.ReunionWinUIVersion }}"'
 
   - task: VSBuild@1
     displayName: 'Build ProjectReunion.Extension.sln'
@@ -40,7 +45,7 @@ jobs:
       solution: dev\VSIX\ProjectReunion.Extension.sln
       platform: 'Any CPU'
       configuration: '$(buildConfiguration)'
-      msBuildArgs: '/p:ReunionVersion="${{ parameters.ReunionVersion }}" /p:ReunionFoundationVersion="${{ parameters.ReunionFoundationVersion }}" /p:ReunionDWriteVersion="${{ parameters.ReunionDWriteVersion }}" /p:ReunionWinUIVersion="${{ parameters.ReunionWinUIVersion }}" '
+      msBuildArgs: '/p:OptionalVSIXVersion="${{ parameters.OptionalVSIXVersion }}" /p:ReunionVersion="${{ parameters.ReunionVersion }}" /p:ReunionFoundationVersion="${{ parameters.ReunionFoundationVersion }}" /p:ReunionDWriteVersion="${{ parameters.ReunionDWriteVersion }}" /p:ReunionWinUIVersion="${{ parameters.ReunionWinUIVersion }}"'
 
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Governance Detection'

--- a/build/ProjectReunion-Create-VSIX.yml
+++ b/build/ProjectReunion-Create-VSIX.yml
@@ -2,15 +2,6 @@ parameters:
   - name: "ReunionVersion"
     type: string
     default: ''
-  - name: "ReunionFoundationVersion"
-    type: string
-    default: ''
-  - name: "ReunionDWriteVersion"
-    type: string
-    default: ''
-  - name: "ReunionWinUIVersion"
-    type: string
-    default: ''
   - name: "releaseBuild"
     type: boolean
     default: True
@@ -37,7 +28,7 @@ jobs:
       solution: dev\VSIX\ProjectReunion.Extension.sln
       platform: 'Any CPU'
       configuration: '$(buildConfiguration)'
-      msBuildArgs: '/t:restore /p:OptionalVSIXVersion="${{ parameters.OptionalVSIXVersion }}" /p:ReunionVersion="${{ parameters.ReunionVersion }}" /p:ReunionFoundationVersion="${{ parameters.ReunionFoundationVersion }}" /p:ReunionDWriteVersion="${{ parameters.ReunionDWriteVersion }}" /p:ReunionWinUIVersion="${{ parameters.ReunionWinUIVersion }}"'
+      msBuildArgs: '/t:restore /p:OptionalVSIXVersion="${{ parameters.OptionalVSIXVersion }}" /p:ReunionVersion="${{ parameters.ReunionVersion }}"'
 
   - task: VSBuild@1
     displayName: 'Build ProjectReunion.Extension.sln'
@@ -45,7 +36,7 @@ jobs:
       solution: dev\VSIX\ProjectReunion.Extension.sln
       platform: 'Any CPU'
       configuration: '$(buildConfiguration)'
-      msBuildArgs: '/p:OptionalVSIXVersion="${{ parameters.OptionalVSIXVersion }}" /p:ReunionVersion="${{ parameters.ReunionVersion }}" /p:ReunionFoundationVersion="${{ parameters.ReunionFoundationVersion }}" /p:ReunionDWriteVersion="${{ parameters.ReunionDWriteVersion }}" /p:ReunionWinUIVersion="${{ parameters.ReunionWinUIVersion }}"'
+      msBuildArgs: '/p:OptionalVSIXVersion="${{ parameters.OptionalVSIXVersion }}" /p:ReunionVersion="${{ parameters.ReunionVersion }}"'
 
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Governance Detection'

--- a/dev/VSIX/Extension/ProjectReunion.Extension.csproj
+++ b/dev/VSIX/Extension/ProjectReunion.Extension.csproj
@@ -212,8 +212,12 @@
     † Note: Yes, this introduces a Year 2088 problem for the locally-built VSIX because the
     final component of the version number can wrap around after 68 years. No, this is not
     a concern because it seems unlikely that we'll go 68 years without resetting the clock
-    by increasing the WinUI version number.
+    by increasing the Project Reunion version number.
   -->
+  <PropertyGroup Condition="'$(VSIXVersion)' == '' AND '$(OptionalVSIXVersion)'!='default' AND '$(OptionalVSIXVersion)'!=''">
+    <!-- Optional VSIX version is provided by the pipeline definition to override package version -->
+    <VSIXVersion>$(OptionalVSIXVersion)</VSIXVersion>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(VSIXVersion)' == ''">
     <TimeSpan>$([System.Math]::Floor($([System.DateTime]::UtcNow.Subtract($([System.DateTime]::Parse('2020-01-01T00:00Z'))).TotalSeconds)))</TimeSpan>
     <VSIXVersion>$(ReunionVersion)</VSIXVersion>

--- a/dev/VSIX/Extension/ProjectReunion.Extension.csproj
+++ b/dev/VSIX/Extension/ProjectReunion.Extension.csproj
@@ -76,13 +76,13 @@
     <PackageReference Include="Microsoft.ProjectReunion" Version="[$(ReunionVersion)]" GeneratePathProperty="true">
       <ExcludeAssets>All</ExcludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ProjectReunion.Foundation" Version="[$(ReunionFoundationVersion)]" GeneratePathProperty="true">
+    <PackageReference Include="Microsoft.ProjectReunion.Foundation" Version="[$(ReunionVersion)]" GeneratePathProperty="true">
       <ExcludeAssets>All</ExcludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ProjectReunion.DWrite" Version="[$(ReunionDWriteVersion)]" GeneratePathProperty="true">
+    <PackageReference Include="Microsoft.ProjectReunion.DWrite" Version="[$(ReunionVersion)]" GeneratePathProperty="true">
       <ExcludeAssets>All</ExcludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ProjectReunion.WinUI" Version="[$(ReunionWinUIVersion)]" GeneratePathProperty="true">
+    <PackageReference Include="Microsoft.ProjectReunion.WinUI" Version="[$(ReunionVersion)]" GeneratePathProperty="true">
       <ExcludeAssets>All</ExcludeAssets>
     </PackageReference>
   </ItemGroup>

--- a/dev/VSIX/Extension/ProjectReunion.Extension.csproj
+++ b/dev/VSIX/Extension/ProjectReunion.Extension.csproj
@@ -219,9 +219,17 @@
     <VSIXVersion>$(OptionalVSIXVersion)</VSIXVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(VSIXVersion)' == ''">
-    <TimeSpan>$([System.Math]::Floor($([System.DateTime]::UtcNow.Subtract($([System.DateTime]::Parse('2020-01-01T00:00Z'))).TotalSeconds)))</TimeSpan>
+    <!-- Use 3-part reunion version, less any tagging suffix -->
     <VSIXVersion>$(ReunionVersion)</VSIXVersion>
-    <VSIXVersion Condition="$(VSIXVersion.Contains(&quot;-&quot;))">$(VSIXVersion.Substring(0, $(VSIXVersion.IndexOf("-")))).$(TimeSpan)</VSIXVersion>
+    <VSIXVersion Condition="$(VSIXVersion.Contains(&quot;-&quot;))">$(VSIXVersion.Substring(0, $(VSIXVersion.IndexOf("-"))))</VSIXVersion>
+    <!-- 
+      Add a timestamp as part 4 of the version for uniqueness, and to ensure newer builds are newer 
+      versions. Note that the timestamp is also included in release builds. This avoids version 
+      sequencing issues between public previews and release versions that might otherwise have the same
+      version number, since VSIX does not support preview tags or other mechanisms to distinguish.
+    -->
+    <TimeSpan>$([System.Math]::Floor($([System.DateTime]::UtcNow.Subtract($([System.DateTime]::Parse('2020-01-01T00:00Z'))).TotalSeconds)))</TimeSpan>
+    <VSIXVersion>$(VSIXVersion).$(TimeSpan)</VSIXVersion>
   </PropertyGroup>
   <Target Name="GetVSIXVersion" Outputs="$(VSIXVersion)" />
   <Target Name="BeforeBuild">


### PR DESCRIPTION
This change pulls up a change from release to main to allow version override on the VSIX. It also permanently adds the timestamp to the VSIX version as part 4, to avoid versioning inversion between preview & release. Finally, it simplifies the pipeline a bit. Now that the main aggregation build uses the same version for all thin packages all the time, there's no need to configure and carry around 4 version numbers. Only one is needed.

