### PR TITLE
Add PRI generation support for all .NET versions greater than 5.

### DIFF
--- a/dev/MRTCore/packaging/Microsoft.ApplicationModel.Resources.PriGen.targets
+++ b/dev/MRTCore/packaging/Microsoft.ApplicationModel.Resources.PriGen.targets
@@ -4,8 +4,7 @@
   <!-- With .NET 5 and above, the propery TargetPlatformIdentifier is not UAP but rather Windows.
        Likewise, for other console apps, TargetPlatformIdentifier is Windows.
        PRI generation in VS apps was developed for UWPs originally. Some of the binaries involved assume
-       that the app is a UWP. The implementation needs to be changed but that'll likely happen as part of
-       moving said binaries to be out-of-box. For now, change the value provided to said binaries to UAP. -->
+       that the app is a UWP. Change the value provided to said binaries to UAP. -->
   <PropertyGroup>
     <TargetPlatformIdentifierAdjusted>$(TargetPlatformIdentifier)</TargetPlatformIdentifierAdjusted>
 

--- a/dev/MRTCore/packaging/Microsoft.ApplicationModel.Resources.PriGen.targets
+++ b/dev/MRTCore/packaging/Microsoft.ApplicationModel.Resources.PriGen.targets
@@ -1,13 +1,18 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="15.0">
 
-  <!-- With .NET 5, the propery TargetPlatformIdentifier is not UAP but rather windows.
-       Likewise, for other console apps, TargetPlatformIdentifier is windows.
-       This file expects UAP for all .NET versions, so adjust. -->
+  <!-- With .NET 5 and above, the propery TargetPlatformIdentifier is not UAP but rather Windows.
+       Likewise, for other console apps, TargetPlatformIdentifier is Windows.
+       PRI generation in VS apps was developed for UWPs originally. Some of the binaries involved assume
+       that the app is a UWP. The implementation needs to be changed but that'll likely happen as part of
+       moving said binaries to be out-of-box. For now, change the value provided to said binaries to UAP. -->
   <PropertyGroup>
     <TargetPlatformIdentifierAdjusted>$(TargetPlatformIdentifier)</TargetPlatformIdentifierAdjusted>
-    <!-- Any .NET 5 version is valid here, hence the regex match! For example, this will match net5.0 and net5.1 (or, net50 and net51 if that format is used). -->
-    <TargetPlatformIdentifierAdjusted Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(TargetFramework)', 'net5')) == 'true'">UAP</TargetPlatformIdentifierAdjusted>
+
+    <!-- Any .NET 5 or greater version is valid here! For example, we wll use UAP if TargetFramework contains net5.0 and net5.1 (or, net50 and net51 if that format is used). -->
+    <TargetFrameworkDotNetString>$([System.Text.RegularExpressions.Regex]::Match("$(TargetFramework)", "net\d"))</TargetFrameworkDotNetString>
+    <TargetPlatformIdentifierAdjusted Condition="'$(TargetFrameworkDotNetString)' != '' AND '$(TargetFrameworkDotNetString.Substring(3))' >= '5'">UAP</TargetPlatformIdentifierAdjusted>
+
     <!-- Add support for console apps. -->
     <TargetPlatformIdentifierAdjusted Condition="'$(OutputType)' == 'Exe'">UAP</TargetPlatformIdentifierAdjusted>
   </PropertyGroup>


### PR DESCRIPTION
**How verified**
*.NET 6*
Used .NET 6 with MRTCore C# sample (lib and app). App built and ran fine.
Specific .NET version: windowsdesktop-runtime-6.0.0-preview.2.21154.2-win-x86.
Target framework of lib:
`<TargetFramework>net6-windows10.0.18362.0</TargetFramework>`
Target framework of app:
`<TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>`

*.NET 5*
Verified MRTCore C# sample (lib and app) work. For this, no changes were made to the sample app (they are already configured for .NET 5).