### PR TITLE
update to cswinrt 1.2.1 and .NET 5.0.5

### DIFF
--- a/dev/MRTCore/build/DownloadDotNetRuntimeInstaller.ps1
+++ b/dev/MRTCore/build/DownloadDotNetRuntimeInstaller.ps1
@@ -13,8 +13,8 @@ if(!(Test-Path $outputDir))
 }
 
 # Find direct download links at https://dotnet.microsoft.com/download/dotnet/5.0
-$downloadurlx86 = "https://download.visualstudio.microsoft.com/download/pr/a8dcbda1-8720-453c-9ec6-5a9d90935643/28754321a8b966f1ce837e6f59035b48/windowsdesktop-runtime-5.0.3-win-x86.exe"
-$downloadurlx64 = "https://download.visualstudio.microsoft.com/download/pr/c6541c87-42f2-4c5d-b6db-2df0dade5e00/13e89a5fec3ddb224cd93dd18b0761ff/windowsdesktop-runtime-5.0.3-win-x64.exe"
+$downloadurlx86 = "https://download.visualstudio.microsoft.com/download/pr/c089205d-4f58-4f8d-ad84-c92eaf2f3411/5cd3f9b3bd089c09df14dbbfb64124a4/windowsdesktop-runtime-5.0.5-win-x86.exe"
+$downloadurlx64 = "https://download.visualstudio.microsoft.com/download/pr/c1ef0b3f-9663-4fc5-85eb-4a9cadacdb87/52b890f91e6bd4350d29d2482038df1c/windowsdesktop-runtime-5.0.5-win-x64.exe"
 
 if($arch -eq "x86")
 {

--- a/dev/MRTCore/build/versions.props
+++ b/dev/MRTCore/build/versions.props
@@ -20,8 +20,8 @@
     <CurrentLiftedIXPPackageVersion>10.0.20170.1001-200713-1000.rs-onecore-dep-ixp1</CurrentLiftedIXPPackageVersion>
     <CurrentWilPackageVersion>1.0.190716.2</CurrentWilPackageVersion>
     <MuxCustomBuildTasksPackageVersion>1.0.83-winui3</MuxCustomBuildTasksPackageVersion>
-    <DotNetCoreSdkVersion>5.0.103</DotNetCoreSdkVersion>
-    <DotNetCoreRuntimeVersion>5.0.3</DotNetCoreRuntimeVersion>
+    <DotNetCoreSdkVersion>5.0.202</DotNetCoreSdkVersion>
+    <DotNetCoreRuntimeVersion>5.0.5</DotNetCoreRuntimeVersion>
     <DetoursVersion>4.0.1</DetoursVersion>
     <CppWinRTVersion>2.0.191217.1</CppWinRTVersion>
     <MicrosoftSourceLinkAzureReposVersion>1.0.0</MicrosoftSourceLinkAzureReposVersion>

--- a/dev/MRTCore/global.json
+++ b/dev/MRTCore/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "5.0.103"
+        "version": "5.0.202"
     },
     "msbuild-sdks": {
         "Microsoft.Build.NoTargets" : "1.0.88"

--- a/dev/MRTCore/mrt/Microsoft.ApplicationModel.Resources/projection/Microsoft.ApplicationModel.Resources.Projection.csproj
+++ b/dev/MRTCore/mrt/Microsoft.ApplicationModel.Resources/projection/Microsoft.ApplicationModel.Resources.Projection.csproj
@@ -8,9 +8,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="1.2.0" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="1.2.1" />
   </ItemGroup>
-  
+
+  <!-- For consistency across Reunion, explicitly reference .NET 5.0.5 SDK (5.0.202 train for VS 16.9.3) -->
+  <ItemGroup>
+    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.18362.15" />
+    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.18362.15" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\src\Microsoft.ApplicationModel.Resources.vcxproj" />
   </ItemGroup>


### PR DESCRIPTION
We're recommending to users moving up to .NET 5.0.5 which just released (equal to 5.0.202 in VS 16.9.3).  WinUI is making this change, along with cswinrt 1.2.1, so MRTCore should be consistent.  