### PR TITLE
Fix Installer Build Warnings

### DIFF
--- a/installer/dev/install.cpp
+++ b/installer/dev/install.cpp
@@ -103,7 +103,7 @@ namespace ProjectReunionInstaller {
     wil::com_ptr<IStream> CreateMemoryStream(const BYTE* data, size_t size)
     {
         wil::com_ptr<IStream> retval;
-        retval.attach(::SHCreateMemStream(data, size));
+        retval.attach(::SHCreateMemStream(data, static_cast<UINT>(size)));
         return retval;
     }
 

--- a/installer/dev/project_reunion_definitions.h
+++ b/installer/dev/project_reunion_definitions.h
@@ -23,63 +23,81 @@
 #define PR_FRAMEWORK_X86_RCID PR_FWPACKAGE_X86
 #define PR_FRAMEWORK_X86_TYPE L"PACKAGE"
 #define PR_FRAMEWORK_X86_RCTYPE PACKAGE
-#define PR_FRAMEWORK_X86_PATH "..\\test\\testpackages\\framework_x86.msix"
+#ifndef PR_FRAMEWORK_X86_PATH
+    #define PR_FRAMEWORK_X86_PATH "..\\test\\testpackages\\framework_x86.msix"
+#endif
 
 // x64 Framework
 #define PR_FRAMEWORK_X64_ID L"PR_FWPACKAGE_X64"
 #define PR_FRAMEWORK_X64_RCID PR_FWPACKAGE_X64
 #define PR_FRAMEWORK_X64_TYPE L"PACKAGE"
 #define PR_FRAMEWORK_X64_RCTYPE PACKAGE
-#define PR_FRAMEWORK_X64_PATH "..\\test\\testpackages\\framework_x64.msix"
+#ifndef PR_FRAMEWORK_X64_PATH
+    #define PR_FRAMEWORK_X64_PATH "..\\test\\testpackages\\framework_x64.msix"
+#endif
 
 // arm64 Framework
 #define PR_FRAMEWORK_ARM64_ID L"PR_FWPACKAGE_ARM64"
 #define PR_FRAMEWORK_ARM64_RCID PR_FWPACKAGE_ARM64
 #define PR_FRAMEWORK_ARM64_TYPE L"PACKAGE"
 #define PR_FRAMEWORK_ARM64_RCTYPE PACKAGE
-#define PR_FRAMEWORK_ARM64_PATH "..\\test\\testpackages\\framework_arm64.msix"
+#ifndef PR_FRAMEWORK_ARM64_PATH
+    #define PR_FRAMEWORK_ARM64_PATH "..\\test\\testpackages\\framework_arm64.msix"
+#endif
 
 // x86 Main
 #define PR_MAIN_X86_ID L"PR_MAINPACKAGE_X86"
 #define PR_MAIN_X86_RCID PR_MAINPACKAGE_X86
 #define PR_MAIN_X86_TYPE L"PACKAGE"
 #define PR_MAIN_X86_RCTYPE PACKAGE
-#define PR_MAIN_X86_PATH "..\\test\\testpackages\\main_x86.msix"
+#ifndef PR_MAIN_X86_PATH
+    #define PR_MAIN_X86_PATH "..\\test\\testpackages\\main_x86.msix"
+#endif
 
 // x64 Main
 #define PR_MAIN_X64_ID L"PR_MAINPACKAGE_X64"
 #define PR_MAIN_X64_RCID PR_MAINPACKAGE_X64
 #define PR_MAIN_X64_TYPE L"PACKAGE"
 #define PR_MAIN_X64_RCTYPE PACKAGE
-#define PR_MAIN_X64_PATH "..\\test\\testpackages\\main_x64.msix"
+#ifndef PR_MAIN_X64_PATH
+    #define PR_MAIN_X64_PATH "..\\test\\testpackages\\main_x64.msix"
+#endif
 
 // arm64 Main
 #define PR_MAIN_ARM64_ID L"PR_MAINPACKAGE_ARM64"
 #define PR_MAIN_ARM64_RCID PR_MAINPACKAGE_ARM64
 #define PR_MAIN_ARM64_TYPE L"PACKAGE"
 #define PR_MAIN_ARM64_RCTYPE PACKAGE
-#define PR_MAIN_ARM64_PATH "..\\test\\testpackages\\main_arm64.msix"
+#ifndef PR_MAIN_ARM64_PATH
+    #define PR_MAIN_ARM64_PATH "..\\test\\testpackages\\main_arm64.msix"
+#endif
 
 // x86 DDLM
 #define PR_DDLM_X86_ID L"PR_DDLMPACKAGE_X86"
 #define PR_DDLM_X86_RCID PR_DDLMPACKAGE_X86
 #define PR_DDLM_X86_TYPE L"PACKAGE"
 #define PR_DDLM_X86_RCTYPE PACKAGE
-#define PR_DDLM_X86_PATH "..\\test\\testpackages\\ddlm_x86.msix"
+#ifndef PR_DDLM_X86_PATH
+    #define PR_DDLM_X86_PATH "..\\test\\testpackages\\ddlm_x86.msix"
+#endif
 
 // x64 DDLM
 #define PR_DDLM_X64_ID L"PR_DDLMPACKAGE_X64"
 #define PR_DDLM_X64_RCID PR_DDLMPACKAGE_X64
 #define PR_DDLM_X64_TYPE L"PACKAGE"
 #define PR_DDLM_X64_RCTYPE PACKAGE
-#define PR_DDLM_X64_PATH "..\\test\\testpackages\\ddlm_x64.msix"
+#ifndef PR_DDLM_X64_PATH
+    #define PR_DDLM_X64_PATH "..\\test\\testpackages\\ddlm_x64.msix"
+#endif
 
 // arm64 DDLM
 #define PR_DDLM_ARM64_ID L"PR_DDLMPACKAGE_ARM64"
 #define PR_DDLM_ARM64_RCID PR_DDLMPACKAGE_ARM64
 #define PR_DDLM_ARM64_TYPE L"PACKAGE"
 #define PR_DDLM_ARM64_RCTYPE PACKAGE
-#define PR_DDLM_ARM64_PATH "..\\test\\testpackages\\ddlm_arm64.msix"
+#ifndef PR_DDLM_ARM64_PATH
+    #define PR_DDLM_ARM64_PATH "..\\test\\testpackages\\ddlm_arm64.msix"
+#endif
 
 
 // Package Inclusion


### PR DESCRIPTION
Fixes some expected warnings in the installer build, particularly when using the override header with redefinition warnings. The header can get pulled in multiple times in the main build and again by the resource compiler.

Verified with running installer tests without issue.