### PR TITLE
In C#/.NET projects, pick up image and resw files for PRI generation.

### DIFF
--- a/dev/MRTCore/packaging/Microsoft.ApplicationModel.Resources.PriGen.targets
+++ b/dev/MRTCore/packaging/Microsoft.ApplicationModel.Resources.PriGen.targets
@@ -21,6 +21,20 @@
     <Content Include="@(Image)" Condition="'$(OutputType)' == 'Exe'" />
   </ItemGroup>
 
+  <!-- The .NET/C# project system does not add the .resw files added to the project to PRIResource, unlike the UWP
+       project system (this is expected since .resw files were historically UWP specific). That is needed for the
+       .resw files to be indexed during PRI generation. Likewise, image files need to be added to Content for them
+       to be indexed. These files exist in the None list by default (meaning without app developer intervention).
+       We address this requirement here so that the app develpoer doesn't need to manually intervene. -->
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+    <!-- Add .resw files to PRIResource so they are indexed. -->
+    <PRIResource Include="@(None->WithMetadataValue('Extension', '.resw'))" />
+    <!-- Add image files to PRIResource so they are indexed. -->
+    <Content Include="@(None->WithMetadataValue('Extension', '.png'))" />
+    <Content Include="@(None->WithMetadataValue('Extension', '.bmp'))" />
+    <Content Include="@(None->WithMetadataValue('Extension', '.jpg'))" />
+  </ItemGroup>
+
   <!--
     Setting default project properties for .NET SDK-style projects
   -->

--- a/dev/MRTCore/packaging/Microsoft.ApplicationModel.Resources.PriGen.targets
+++ b/dev/MRTCore/packaging/Microsoft.ApplicationModel.Resources.PriGen.targets
@@ -25,7 +25,7 @@
        project system (this is expected since .resw files were historically UWP specific). That is needed for the
        .resw files to be indexed during PRI generation. Likewise, image files need to be added to Content for them
        to be indexed. These files exist in the None list by default (meaning without app developer intervention).
-       We address this requirement here so that the app develpoer doesn't need to manually intervene. -->
+       We address this requirement here so that the app developer doesn't need to manually intervene. -->
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <!-- Add .resw files to PRIResource so they are indexed. -->
     <PRIResource Include="@(None->WithMetadataValue('Extension', '.resw'))" />

--- a/dev/MRTCore/packaging/Microsoft.ApplicationModel.Resources.PriGen.targets
+++ b/dev/MRTCore/packaging/Microsoft.ApplicationModel.Resources.PriGen.targets
@@ -33,6 +33,10 @@
     <Content Include="@(None->WithMetadataValue('Extension', '.png'))" />
     <Content Include="@(None->WithMetadataValue('Extension', '.bmp'))" />
     <Content Include="@(None->WithMetadataValue('Extension', '.jpg'))" />
+    <Content Include="@(None->WithMetadataValue('Extension', '.dds'))" />
+    <Content Include="@(None->WithMetadataValue('Extension', '.tif'))" />
+    <Content Include="@(None->WithMetadataValue('Extension', '.tga'))" />
+    <Content Include="@(None->WithMetadataValue('Extension', '.gif'))" />
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
This wasn't done in all cases. See the note in this page https://docs.microsoft.com/en-us/windows/apps/project-reunion/mrtcore/mrtcore-overview:
"
Before you can use MRT Core to retrieve strings and images in a WinUI 3 project that uses C#/.NET 5, you must ensure that these resources are configured so that they can be indexed in the resources.pri file. Otherwise, these resources cannot be retrieved by MRT Core.

Strings: Make sure the Build Action property for resources files (.resw) is set to PRIResource. This property is set automatically if you add a new Resources File (.resw) item to your project.
Images: Make sure the Build Action property for image files are set to Content. This property is set automatically if you add an existing image to a folder named Assets in your project.
"

Addresses: #613 

**How verified**
With the .NET/C# MRT Core sample app, added a PNG, a BMP, a JPG and a RESW file. After building the app, the resources do show up in the PRI as expected.