### PR TITLE
Publish stub intellisense files into transport package

### DIFF
--- a/build/AzurePipelinesTemplates/ProjectReunion-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/ProjectReunion-CreateNugetPackage-Job.yml
@@ -62,6 +62,9 @@ jobs:
 
         Copy-Item -Path "$targetsFilePath\AppxManifest.xml" -Destination "$fullpackagePath\AppxManifest.xml"
 
+        Copy-Item -Path "$targetsFilePath\Intellisense\Microsoft.ApplicationModel.Activation.xml" -Destination "$fullpackagePath\lib\uap10.0\Microsoft.ApplicationModel.Activation.xml"
+        Copy-Item -Path "$targetsFilePath\Intellisense\Microsoft.ApplicationModel.DynamicDependency.xml" -Destination "$fullpackagePath\lib\uap10.0\Microsoft.ApplicationModel.DynamicDependency.xml"
+
   # debugging - remove or comment out before completing PR      
   # - script: |
   #     dir /s $(Build.SourcesDirectory)

--- a/build/NuSpecs/Intellisense/Microsoft.ApplicationModel.Activation.xml
+++ b/build/NuSpecs/Intellisense/Microsoft.ApplicationModel.Activation.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<doc>
+  <assembly>
+    <name>Microsoft.ApplicationModel.Activation</name>
+  </assembly>
+  <members>
+  </members>
+</doc>
+

--- a/build/NuSpecs/Intellisense/Microsoft.ApplicationModel.DynamicDependency.xml
+++ b/build/NuSpecs/Intellisense/Microsoft.ApplicationModel.DynamicDependency.xml
@@ -1,0 +1,10 @@
+
+<?xml version="1.0" encoding="utf-8"?>
+<doc>
+  <assembly>
+    <name>Microsoft.ApplicationModel.DynamicDependency</name>
+  </assembly>
+  <members>
+  </members>
+</doc>
+

--- a/build/publish-mrt.yml
+++ b/build/publish-mrt.yml
@@ -27,6 +27,15 @@ steps:
     TargetFolder: '$(Build.ArtifactStagingDirectory)\fullnuget\lib\uap10.0\'
     flattenFolders: true
 
+- task: CopyFiles@2
+  displayName: 'copy Intellisense into uap10.0 folder'
+  inputs:
+    SourceFolder: '$(MRTSourcesDirectory)\packaging\Intellisense'
+    Contents: |
+      Microsoft.ApplicationModel.Resources.xml
+    TargetFolder: '$(Build.ArtifactStagingDirectory)\fullnuget\lib\uap10.0\'
+    flattenFolders: true
+
 # Needed so that the NuGet package can be installed in a win32 app. It avoids this error: "You are trying to
 # install this package into a project that targets 'native,Version=v0.0', but the package does not contain any
 # assembly references or content files that are compatible with that framework."
@@ -36,6 +45,15 @@ steps:
     SourceFolder: '$(Build.ArtifactStagingDirectory)\mrt_raw\mrtcore_binaries\lib\anycpu'
     Contents: |
       Microsoft.ApplicationModel.Resources.winmd
+    TargetFolder: '$(Build.ArtifactStagingDirectory)\fullnuget\lib\native\'
+    flattenFolders: true
+
+- task: CopyFiles@2
+  displayName: 'copy Intellisense into native folder'
+  inputs:
+    SourceFolder: '$(MRTSourcesDirectory)\packaging\Intellisense'
+    Contents: |
+      Microsoft.ApplicationModel.Resources.xml
     TargetFolder: '$(Build.ArtifactStagingDirectory)\fullnuget\lib\native\'
     flattenFolders: true
 

--- a/build/publish-mrt.yml
+++ b/build/publish-mrt.yml
@@ -68,6 +68,15 @@ steps:
     flattenFolders: true
 
 - task: CopyFiles@2
+  displayName: 'copy Intellisense into .net 5 folder'
+  inputs:
+    SourceFolder: '${{ parameters.MRTSourcesDirectory }}\packaging\Intellisense'
+    Contents: |
+      Microsoft.ApplicationModel.Resources.Projection.xml
+    TargetFolder: '$(Build.ArtifactStagingDirectory)\fullnuget\lib\net5.0-windows\'
+    flattenFolders: true
+
+- task: CopyFiles@2
   displayName: 'copy x86'
   inputs:
     SourceFolder: '$(Build.ArtifactStagingDirectory)\mrt_raw\mrtcore_binaries\lib\x86'

--- a/build/publish-mrt.yml
+++ b/build/publish-mrt.yml
@@ -30,7 +30,7 @@ steps:
 - task: CopyFiles@2
   displayName: 'copy Intellisense into uap10.0 folder'
   inputs:
-    SourceFolder: '$(MRTSourcesDirectory)\packaging\Intellisense'
+    SourceFolder: '${{ parameters.MRTSourcesDirectory }}\packaging\Intellisense'
     Contents: |
       Microsoft.ApplicationModel.Resources.xml
     TargetFolder: '$(Build.ArtifactStagingDirectory)\fullnuget\lib\uap10.0\'
@@ -51,7 +51,7 @@ steps:
 - task: CopyFiles@2
   displayName: 'copy Intellisense into native folder'
   inputs:
-    SourceFolder: '$(MRTSourcesDirectory)\packaging\Intellisense'
+    SourceFolder: '${{ parameters.MRTSourcesDirectory }}\packaging\Intellisense'
     Contents: |
       Microsoft.ApplicationModel.Resources.xml
     TargetFolder: '$(Build.ArtifactStagingDirectory)\fullnuget\lib\native\'

--- a/dev/MRTCore/packaging/Intellisense/Microsoft.ApplicationModel.Resources.Projection.xml
+++ b/dev/MRTCore/packaging/Intellisense/Microsoft.ApplicationModel.Resources.Projection.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<doc>
+  <assembly>
+    <name>Microsoft.ApplicationModel.Resources.Projection</name>
+  </assembly>
+  <members>
+  </members>
+</doc>
+

--- a/dev/MRTCore/packaging/Intellisense/Microsoft.ApplicationModel.Resources.xml
+++ b/dev/MRTCore/packaging/Intellisense/Microsoft.ApplicationModel.Resources.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <doc>
   <assembly>
-    <name>Microsoft.ProjectReunion</name>
+    <name>Microsoft.ApplicationModel.Resources</name>
   </assembly>
   <members>
   </members>


### PR DESCRIPTION
With this change, we'll be publishing stubbed out Intellisense xml files into the transport package, and subsequently into the Project Reunion package.

Feature owners still need to fill in the Intellisense documentation, but these changes won't require pipeline changes, simply text changes to the xml file(s).