### PR TITLE
Fixes for Preview VSIX

### DIFF
--- a/dev/VSIX/Directory.Build.targets
+++ b/dev/VSIX/Directory.Build.targets
@@ -52,10 +52,32 @@
             <Output TaskParameter="Result" PropertyName="_tempVsTemplateDisplayName" />
         </XmlPeek>
 
+        <XmlPeek
+            XmlInputPath="%(AllVSTemplates.Identity)"
+            Query="/ns:VSTemplate/ns:WizardData/ns:packages/@repositoryId"
+            Namespaces="&lt;Namespace Prefix='ns' Uri='http://schemas.microsoft.com/developer/vstemplate/2005' /&gt;">
+            <Output TaskParameter="Result" PropertyName="_tempVsTemplateNugetRepositoryId" />
+        </XmlPeek>
+
+        <XmlPeek
+            XmlInputPath="%(AllVSTemplates.Identity)"
+            Query="/ns:VSTemplate/ns:TemplateData/ns:TemplateID/text()"
+            Namespaces="&lt;Namespace Prefix='ns' Uri='http://schemas.microsoft.com/developer/vstemplate/2005' /&gt;">
+            <Output TaskParameter="Result" PropertyName="_tempVsTemplateId" />
+        </XmlPeek>
+
         <ItemGroup>
             <AllVSTemplates Condition="'%(AllVSTemplates.Identity)' == '%(Identity)'" >
                 <OriginalDisplayName>$(_tempVsTemplateDisplayName)</OriginalDisplayName>
                 <ExperimentalDisplayName>[Experimental] $(_tempVsTemplateDisplayName)</ExperimentalDisplayName>
+
+                <OriginalTemplateId>$(_tempVsTemplateId)</OriginalTemplateId>
+                <ExperimentalTemplateId>$(_tempVsTemplateId).Preview</ExperimentalTemplateId>
+
+                <OriginalNugetRepositoryId>$(_tempVsTemplateNugetRepositoryId)</OriginalNugetRepositoryId>
+                <!-- 'ExperimentalNugetRepositoryId' needs to match the value set by the XmlPoke query for
+                "/ns:PackageManifest/ns:Metadata/ns:Identity/@Id" in Extension\ProjectReunion.Extension.csproj -->
+                <ExperimentalNugetRepositoryId>$(_tempVsTemplateNugetRepositoryId).Preview</ExperimentalNugetRepositoryId>
             </AllVSTemplates>
         </ItemGroup>
 
@@ -70,6 +92,7 @@
         DependsOnTargets="PrepareForVsTemplateUpdates"
         Condition="'@(AllVSTemplates)' != ''">
 
+        <!-- Update .vstemplate Nuget package versions to restore -->
         <XmlPoke XmlInputPath="%(AllVSTemplates.Identity)"
             Query="/ns:VSTemplate/ns:WizardData/ns:packages/ns:package[@id='Microsoft.Windows.CppWinRT']/@version"
             Value="$(CppWinRTVersion)" Namespaces="&lt;Namespace Prefix='ns' Uri='http://schemas.microsoft.com/developer/vstemplate/2005' /&gt;" />
@@ -86,6 +109,7 @@
             Query="/ns:VSTemplate/ns:WizardData/ns:packages/ns:package[@id='Microsoft.ProjectReunion.WinUI']/@version"
             Value="$(ReunionVersion)" Namespaces="&lt;Namespace Prefix='ns' Uri='http://schemas.microsoft.com/developer/vstemplate/2005' /&gt;" />
 
+        <!-- Update Assets manifest with actual Nuget package filenames -->
         <XmlPoke XmlInputPath="%(AllVSTemplates.Identity)"
             Query="/ns:VSTemplate/ns:WizardData/ns:Assets/ns:Asset[@Type='Microsoft.Windows.CppWinRT.nupkg']/@Path"
             Value="Microsoft.Windows.CppWinRT.$(CppWinRTVersion).nupkg" Namespaces="&lt;Namespace Prefix='ns' Uri='http://schemas.microsoft.com/developer/vstemplate/2005' /&gt;" />
@@ -102,6 +126,7 @@
             Query="/ns:VSTemplate/ns:WizardData/ns:Assets/ns:Asset[@Type='Microsoft.ProjectReunion.WinUI.nupkg']/@Path"
             Value="Microsoft.ProjectReunion.WinUI.$(ReunionVersion).nupkg" Namespaces="&lt;Namespace Prefix='ns' Uri='http://schemas.microsoft.com/developer/vstemplate/2005' /&gt;" />
 
+        <!-- Update custom parameters passed into subtemplates -->
         <XmlPoke XmlInputPath="%(AllVSTemplates.Identity)"
             Query="/ns:VSTemplate/ns:TemplateContent/ns:CustomParameters/ns:CustomParameter[@Name='$CppWinRTVersion$']/@Value"
             Value="$(CppWinRTVersion)" Namespaces="&lt;Namespace Prefix='ns' Uri='http://schemas.microsoft.com/developer/vstemplate/2005' /&gt;" />
@@ -125,10 +150,26 @@
             Query="/ns:VSTemplate/ns:TemplateData/ns:Name"
             Value="%(AllVSTemplates.ExperimentalDisplayName)"
             Namespaces="&lt;Namespace Prefix='ns' Uri='http://schemas.microsoft.com/developer/vstemplate/2005' /&gt;"/>
+
+        <!-- Update .vstemplate with Experimental TemplateId if necessary -->
+        <XmlPoke
+            Condition="'$(EnableExperimentalVSIXFeatures)'=='true'"
+            XmlInputPath="%(AllVSTemplates.Identity)"
+            Query="/ns:VSTemplate/ns:TemplateData/ns:TemplateID"
+            Value="%(AllVSTemplates.ExperimentalTemplateId)"
+            Namespaces="&lt;Namespace Prefix='ns' Uri='http://schemas.microsoft.com/developer/vstemplate/2005' /&gt;"/>
+
+        <!-- Update .vstemplate's Nuget package repository with the Experimental extension ID if necessary -->
+        <XmlPoke
+            Condition="'$(EnableExperimentalVSIXFeatures)'=='true'"
+            XmlInputPath="%(AllVSTemplates.Identity)"
+            Query="/ns:VSTemplate/ns:WizardData/ns:packages/@repositoryId"
+            Value="%(AllVSTemplates.ExperimentalNugetRepositoryId)"
+            Namespaces="&lt;Namespace Prefix='ns' Uri='http://schemas.microsoft.com/developer/vstemplate/2005' /&gt;"/>
     </Target>
 
     <!--
-        This target is used to revert those versions back to 1.0.0 so that we don't leave files modified on disk.
+        This target is used to revert the changes made by the UpdateVsTemplates target so that we don't leave files modified on disk.
     -->
     <Target Name="RestoreVsTemplates"
         AfterTargets="BuiltProjectOutputGroupDependencies;Build"
@@ -186,12 +227,25 @@
             Query="/ns:VSTemplate/ns:TemplateContent/ns:CustomParameters/ns:CustomParameter[@Name='$ReunionWinUINupkgVersion$']/@Value"
             Value="$(DefaultVersion)" Namespaces="&lt;Namespace Prefix='ns' Uri='http://schemas.microsoft.com/developer/vstemplate/2005' /&gt;" />
 
-        <!-- Restore original display name for .vstemplate if necessary -->
         <XmlPoke
-            Condition="'$(EnableExperimentalVSIXFeatures)'=='true'"
+            Condition="'$(EnableExperimentalVSIXFeatures)'=='true' and '%(AllVSTemplates.OriginalDisplayName)'!=''"
             XmlInputPath="%(AllVSTemplates.Identity)"
             Query="/ns:VSTemplate/ns:TemplateData/ns:Name"
             Value="%(AllVSTemplates.OriginalDisplayName)"
+            Namespaces="&lt;Namespace Prefix='ns' Uri='http://schemas.microsoft.com/developer/vstemplate/2005' /&gt;"/>
+
+        <XmlPoke
+            Condition="'$(EnableExperimentalVSIXFeatures)'=='true' and '%(AllVSTemplates.OriginalTemplateId)'!=''"
+            XmlInputPath="%(AllVSTemplates.Identity)"
+            Query="/ns:VSTemplate/ns:TemplateData/ns:TemplateID"
+            Value="%(AllVSTemplates.OriginalTemplateId)"
+            Namespaces="&lt;Namespace Prefix='ns' Uri='http://schemas.microsoft.com/developer/vstemplate/2005' /&gt;"/>
+
+        <XmlPoke
+            Condition="'$(EnableExperimentalVSIXFeatures)'=='true' and '%(AllVSTemplates.OriginalNugetRepositoryId)'!=''"
+            XmlInputPath="%(AllVSTemplates.Identity)"
+            Query="/ns:VSTemplate/ns:WizardData/ns:packages/@repositoryId"
+            Value="%(AllVSTemplates.OriginalNugetRepositoryId)"
             Namespaces="&lt;Namespace Prefix='ns' Uri='http://schemas.microsoft.com/developer/vstemplate/2005' /&gt;"/>
     </Target>
 

--- a/dev/VSIX/Extension/ProjectReunion.Extension.csproj
+++ b/dev/VSIX/Extension/ProjectReunion.Extension.csproj
@@ -275,14 +275,11 @@
       Namespaces="&lt;Namespace Prefix='ns' Uri='http://schemas.microsoft.com/developer/vsx-schema/2011' /&gt;">
       <Output TaskParameter="Result" PropertyName="_OriginalVsixTags" />
     </XmlPeek>
-    <XmlPeek
-      XmlInputPath="$(VsixManifestSource)"
-      Query="/ns:PackageManifest/ns:Metadata/ns:Preview/text()"
-      Namespaces="&lt;Namespace Prefix='ns' Uri='http://schemas.microsoft.com/developer/vsx-schema/2011' /&gt;">
-      <Output TaskParameter="Result" PropertyName="_OriginalVsixPreviewStatus" />
-    </XmlPeek>
 
     <!-- Update the .vsixmanifest to reflect preview status if necessary -->
+
+    <!-- The value set here for the Id needs to match that set for 'ExperimentalNugetRepositoryId' in
+    ..\Directory.Build.targets -->
     <XmlPoke
       Condition="'$(EnableExperimentalVSIXFeatures)'=='true'"
       XmlInputPath="$(VsixManifestSource)"
@@ -300,12 +297,6 @@
       XmlInputPath="$(VsixManifestSource)"
       Query="/ns:PackageManifest/ns:Metadata/ns:Tags"
       Value="$(_OriginalVsixTags), UWP"
-      Namespaces="&lt;Namespace Prefix='ns' Uri='http://schemas.microsoft.com/developer/vsx-schema/2011' /&gt;" />
-    <XmlPoke
-      Condition="'$(EnableExperimentalVSIXFeatures)'=='true'"
-      XmlInputPath="$(VsixManifestSource)"
-      Query="/ns:PackageManifest/ns:Metadata/ns:Preview"
-      Value="true"
       Namespaces="&lt;Namespace Prefix='ns' Uri='http://schemas.microsoft.com/developer/vsx-schema/2011' /&gt;" />
   </Target>
   <Target Name="AfterBuild">
@@ -330,11 +321,6 @@
       XmlInputPath="$(VsixManifestSource)"
       Query="/ns:PackageManifest/ns:Metadata/ns:Tags"
       Value="$(_OriginalVsixTags)"
-      Namespaces="&lt;Namespace Prefix='ns' Uri='http://schemas.microsoft.com/developer/vsx-schema/2011' /&gt;" />
-    <XmlPoke
-      XmlInputPath="$(VsixManifestSource)"
-      Query="/ns:PackageManifest/ns:Metadata/ns:Preview"
-      Value="$(_OriginalVsixPreviewStatus)"
       Namespaces="&lt;Namespace Prefix='ns' Uri='http://schemas.microsoft.com/developer/vsx-schema/2011' /&gt;" />
   </Target>
 </Project>

--- a/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/WapProj/WapProjTemplate.wapproj
+++ b/dev/VSIX/ProjectTemplates/Desktop/CSharp/PackagedApp/WapProj/WapProjTemplate.wapproj
@@ -35,7 +35,6 @@
   <PropertyGroup>
     <WapProjPath Condition="'$(WapProjPath)'==''">$(MSBuildExtensionsPath)\Microsoft\DesktopBridge\</WapProjPath>
     <PathToXAMLWinRTImplementations>$ext_projectname$\</PathToXAMLWinRTImplementations>
-    <AssetTargetFallback>net5.0-windows$(TargetPlatformVersion);$(AssetTargetFallback)</AssetTargetFallback>      
   </PropertyGroup>
 
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.props" />
@@ -44,6 +43,7 @@
     <ProjectGuid>$guid1$</ProjectGuid>
     <TargetPlatformVersion>$targetplatformversion$</TargetPlatformVersion>
     <TargetPlatformMinVersion>$targetplatformminversion$</TargetPlatformMinVersion>
+    <AssetTargetFallback>net5.0-windows$(TargetPlatformVersion);$(AssetTargetFallback)</AssetTargetFallback>
     <DefaultLanguage>$currentuiculturename$</DefaultLanguage>
     $if$($includeKeyFile$==true)
     <PackageCertificateKeyFile>$projectname$_TemporaryKey.pfx</PackageCertificateKeyFile>
@@ -85,7 +85,7 @@
       <IncludeAssets>build</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-  
+
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.targets" />
 
 </Project>


### PR DESCRIPTION
During testing, we discovered some issues with the preview VSIX:
* Missing project templates if both GA and Preview VSIX were installed side-by-side
Resolved by appending `.Preview` to TemplateID of all templates in preview VSIX
* Nuget restore error when creating new C++ projects
Resolved by ensuring that the Nuget template wizard data was pointing at the correct extension ID to use as a source repository
* Nuget compatibility error from .wapproj when using VS 16.10 Preview to build a Desktop WinUI app
The `AssetTargetFallback` property needs to be defined after the definition of the `TargetPlatformVersion` property as the former has a dependency on the latter.

Additionally, we decided to not set the `Preview` flag in the Preview VSIX's manifest as the title already declares it to be a preview.