### PR TITLE
Remove obsolete reference to file Microsoft.ProjectReunion.winmd which doesn't exist anymore

### DIFF
--- a/build/NuSpecs/ProjectReunion-Nuget-Native.targets
+++ b/build/NuSpecs/ProjectReunion-Nuget-Native.targets
@@ -6,13 +6,4 @@
     <Native-Platform Condition="'$(Platform)' == 'Win32'">x86</Native-Platform>
     <Native-Platform Condition="'$(Platform)' != 'Win32'">$(Platform)</Native-Platform>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.ProjectReunion.winmd">
-      <Private>false</Private>
-      <Implementation>Microsoft.ProjectReunion.dll</Implementation>
-    </Reference>
-    <!--  Figure out the right long term approach for VS to not pick these up when using them with a framework package. -->
-    <!-- <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(Native-Platform)\native\Microsoft.ProjectReunion.dll" /> -->
-    <!-- <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(Native-Platform)\native\Microsoft.ProjectReunion.pri" /> -->
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
Symbols moved to other namespaces making this reference obsolete