### PR TITLE
Update Nuspecs for unpackaged consumption

### DIFF
--- a/build/NuSpecs/ProjectReunion-Nuget-Native.C.props
+++ b/build/NuSpecs/ProjectReunion-Nuget-Native.C.props
@@ -6,10 +6,6 @@
     <_ProjectReunionFoundationPlatform Condition="'$(Platform)' != 'Win32'">$(Platform)</_ProjectReunionFoundationPlatform>
   </PropertyGroup>
 
-  <!--
-    Some of the manual reference adding below may not be necessary due to the files in question being in default locations, but there's no harm in it.
-  -->
-
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -20,10 +16,21 @@
     <Link>
       <AdditionalDependencies>
         $(MSBuildThisFileDirectory)..\..\lib\win10-$(_ProjectReunionFoundationPlatform)\Microsoft.ProjectReunion.lib;
+        %(AdditionalDependencies);
+      </AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+
+  <ItemDefinitionGroup Condition="'$(AppxPackage)' != 'true'">
+    <Link>
+      <AdditionalDependencies>
         $(MSBuildThisFileDirectory)..\..\lib\win10-$(_ProjectReunionFoundationPlatform)\Microsoft.ProjectReunion.Bootstrap.lib;
         %(AdditionalDependencies);
       </AdditionalDependencies>
     </Link>
+    <PostBuildEvent>
+      <Command>xcopy /y "$(MSBuildThisFileDirectory)..\..\runtimes\lib\native\$(_ProjectReunionFoundationPlatform)\Microsoft.ProjectReunion.Bootstrap.dll" "$(OutDir)"</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
 
 </Project>

--- a/build/NuSpecs/ProjectReunion-Nuget-Native.WinRt.props
+++ b/build/NuSpecs/ProjectReunion-Nuget-Native.WinRt.props
@@ -9,15 +9,15 @@
   <ItemGroup Condition="'$(AppxPackage)' != 'true'">
     <Reference Include="Microsoft.ApplicationModel.DynamicDependency.winmd">
       <HintPath>$(MSBuildThisFileDirectory)..\..\lib\native\Microsoft.ApplicationModel.DynamicDependency.winmd</HintPath>
-      <Implementation Condition="'$(ProjectReunionFrameworkPackage)' != 'true'">$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(_ProjectReunionFoundationPlatform)\native\Microsoft.ApplicationModel.DynamicDependency.dll</Implementation>
+      <Implementation Condition="'$(ProjectReunionFrameworkPackage)' != 'true'">$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(_ProjectReunionFoundationPlatform)\native\Microsoft.ProjectReunion.dll</Implementation>
       <IsWinMDFile>true</IsWinMDFile>
     </Reference>
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.ApplicationModel.Activation.winmd">
-      <HintPath>$(MSBuildThisFileDirectory)..\..\lib\native\Microsoft.ApplicationModel.Activation.winmd</HintPath>
-      <Implementation Condition="'$(ProjectReunionFrameworkPackage)' != 'true'">$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(_ProjectReunionFoundationPlatform)\native\Microsoft.ApplicationModel.AppLifecycle.dll</Implementation>
+    <Reference Include="Microsoft.Windows.AppLifecycle.winmd">
+      <HintPath>$(MSBuildThisFileDirectory)..\..\lib\native\Microsoft.Windows.AppLifecycle.winmd</HintPath>
+      <Implementation Condition="'$(ProjectReunionFrameworkPackage)' != 'true'">$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(_ProjectReunionFoundationPlatform)\native\Microsoft.ProjectReunion.dll</Implementation>
       <IsWinMDFile>true</IsWinMDFile>
     </Reference>
   </ItemGroup>

--- a/build/NuSpecs/ProjectReunion-Nuget-Native.WinRt.props
+++ b/build/NuSpecs/ProjectReunion-Nuget-Native.WinRt.props
@@ -6,18 +6,18 @@
     <_ProjectReunionFoundationPlatform Condition="'$(Platform)' != 'Win32'">$(Platform)</_ProjectReunionFoundationPlatform>
   </PropertyGroup>
 
-  <!-- Some of the manual reference adding below may not be necessary due to the files in question being in default locations, but there's no harm in it. -->
-
-  <!-- OutputType Exe corresponds to C++ -->
-  <ItemGroup Condition="'$(OutputType)' == 'Exe'">
-    <Reference Include="Microsoft.Windows.AppLifecycle.winmd">
-      <HintPath>$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Windows.AppLifecycle.winmd</HintPath>
-      <Implementation Condition="'$(ProjectReunionFrameworkPackage)' != 'true'">$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(_ProjectReunionFoundationPlatform)\native\Microsoft.Windows.AppLifecycle.dll</Implementation>
+  <ItemGroup Condition="'$(AppxPackage)' != 'true'">
+    <Reference Include="Microsoft.ApplicationModel.DynamicDependency.winmd">
+      <HintPath>$(MSBuildThisFileDirectory)..\..\lib\native\Microsoft.ApplicationModel.DynamicDependency.winmd</HintPath>
+      <Implementation Condition="'$(ProjectReunionFrameworkPackage)' != 'true'">$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(_ProjectReunionFoundationPlatform)\native\Microsoft.ApplicationModel.DynamicDependency.dll</Implementation>
       <IsWinMDFile>true</IsWinMDFile>
     </Reference>
-    <Reference Include="Microsoft.ApplicationModel.DynamicDependency.winmd">
-      <HintPath>$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.ApplicationModel.DynamicDependency.winmd</HintPath>
-      <Implementation Condition="'$(ProjectReunionFrameworkPackage)' != 'true'">$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(_ProjectReunionFoundationPlatform)\native\Microsoft.ApplicationModel.DynamicDependency.dll</Implementation>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.ApplicationModel.Activation.winmd">
+      <HintPath>$(MSBuildThisFileDirectory)..\..\lib\native\Microsoft.ApplicationModel.Activation.winmd</HintPath>
+      <Implementation Condition="'$(ProjectReunionFrameworkPackage)' != 'true'">$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(_ProjectReunionFoundationPlatform)\native\Microsoft.ApplicationModel.AppLifecycle.dll</Implementation>
       <IsWinMDFile>true</IsWinMDFile>
     </Reference>
   </ItemGroup>

--- a/build/NuSpecs/ProjectReunion-Nuget-Native.targets
+++ b/build/NuSpecs/ProjectReunion-Nuget-Native.targets
@@ -1,9 +1,26 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.ApplicationModel.Resources.targets"/>
+
   <PropertyGroup>
     <Native-Platform Condition="'$(Platform)' == 'Win32'">x86</Native-Platform>
     <Native-Platform Condition="'$(Platform)' != 'Win32'">$(Platform)</Native-Platform>
   </PropertyGroup>
+
+  <ItemGroup Condition="'$(AppxPackage)' != 'true'">
+    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\native\Microsoft.ApplicationModel.DynamicDependency.winmd">
+      <Private>false</Private>
+      <Implementation>Microsoft.ProjectReunion.dll</Implementation>
+    </Reference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\native\Microsoft.ApplicationModel.Activation.winmd">
+      <Private>false</Private>
+      <Implementation>Microsoft.ProjectReunion.dll</Implementation>
+    </Reference>
+  </ItemGroup>
+
 </Project>

--- a/build/NuSpecs/ProjectReunion-Nuget-Native.targets
+++ b/build/NuSpecs/ProjectReunion-Nuget-Native.targets
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\native\Microsoft.ApplicationModel.Activation.winmd">
+    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\native\Microsoft.Windows.AppLifecycle.winmd">
       <Private>false</Private>
       <Implementation>Microsoft.ProjectReunion.dll</Implementation>
     </Reference>


### PR DESCRIPTION
Correct some Nuspec files for VS C++ consumption for unpackaged apps

Correct Nuget content determined via VS simple C++ project with a dependency on Project Reunion followed by repeated hacking the NuGet's native build files until the desired outcome, then porting the local changes to the checked in Nuspecs. Fun fun.