### PR TITLE
Remove custom.props

### DIFF
--- a/dev/MRTCore/mrt/Microsoft.ApplicationModel.Resources/custom.props
+++ b/dev/MRTCore/mrt/Microsoft.ApplicationModel.Resources/custom.props
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- custom.props file for Package ES builds of Microsoft.ApplicationModel.Resources -->
-<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <PropertyGroup>
-      <OutputSubDir>$(MSBuildProjectName)</OutputSubDir>
-    </PropertyGroup>
-</Project>


### PR DESCRIPTION
The file was used for building in Package ES lab. We no longer use Package ES build. 