### PR TITLE
Convert MRT Core UnitTests from MSTest to TAEF

### DIFF
--- a/build/Helix/ConvertWttLogToXUnit.ps1
+++ b/build/Helix/ConvertWttLogToXUnit.ps1
@@ -12,6 +12,6 @@ Param(
     [string]$helixworkitem
 )
 
-Add-Type -Language CSharp -ReferencedAssemblies System.Xml,System.Xml.Linq (Get-Content .\ConvertWttLogToXUnit.cs -Raw)
+Add-Type -Language CSharp -ReferencedAssemblies System.Xml,System.Xml.Linq (Get-Content $PSScriptRoot\ConvertWttLogToXUnit.cs -Raw)
 
 [HelixTestHelpers.TestResultParser]::ConvertWttLogToXUnitLog($WttInputPath, $XUnitOutputPath, $testNamePrefix, $helixworkitem)

--- a/build/build-mrt.yml
+++ b/build/build-mrt.yml
@@ -249,3 +249,4 @@ steps:
   inputs:
     PathtoPublish: '$(Build.ArtifactStagingDirectory)\mrt_test'
     ArtifactName: 'mrtcore_test'
+  condition: or(eq(variables['BuildPlatform'], 'x64'), eq(variables['BuildPlatform'], 'x86'))

--- a/build/build-mrt.yml
+++ b/build/build-mrt.yml
@@ -151,9 +151,7 @@ steps:
   inputs:
     targetType: filePath
     filePath: build\Helix\ConvertWttLogToXUnit.ps1
-    arguments: -WttInputPath $LogPath -WttSingleRerunInputPath 'unused.wtl' -WttMultipleRerunInputPath 'unused2.wtl' -XUnitOutputPath 'onBuildMachineResults.xml' -TestNamePrefix '$(BuildConfiguration).$(BuildPlatform)'
-  env:
-    LogPath: ${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)\UnitTest\MrtUnitTest.wtl
+    arguments: -WttInputPath '${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)\UnitTest\MrtUnitTest.wtl' -WttSingleRerunInputPath 'unused.wtl' -WttMultipleRerunInputPath 'unused2.wtl' -XUnitOutputPath 'onBuildMachineResults.xml' -TestNamePrefix '$(BuildConfiguration).$(BuildPlatform)'
   condition: or(eq(variables['BuildPlatform'], 'x64'), eq(variables['BuildPlatform'], 'x86'))
 
 - task: PublishTestResults@2

--- a/build/build-mrt.yml
+++ b/build/build-mrt.yml
@@ -135,53 +135,53 @@ steps:
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
 
-- task: CmdLine@2
-  displayName: 'test MRT - UnitTest'
-  inputs:
-    script: te.exe UnitTest.dll /enablewttlogging /appendwttlogging /logFile:%LogPath%
-    workingDirectory: '${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)\UnitTest'
-  env:
-    LogPath: ${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)\UnitTest\MrtUnitTest.wtl
-  condition: or(eq(variables.buildPlatform, 'x64'), eq(variables.buildPlatform, 'x86'))
+# - task: CmdLine@2
+#   displayName: 'test MRT - UnitTest'
+#   inputs:
+#     script: te.exe UnitTest.dll /enablewttlogging /appendwttlogging /logFile:%LogPath%
+#     workingDirectory: '${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)\UnitTest'
+#   env:
+#     LogPath: ${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)\UnitTest\MrtUnitTest.wtl
+#   condition: or(eq(variables.buildPlatform, 'x64'), eq(variables.buildPlatform, 'x86'))
 
-- task: PowerShell@2
-  displayName: 'Convert Test Logs from WTL to xUnit format'
-  inputs:
-    targetType: filePath
-    filePath: build\Helix\ConvertWttLogToXUnit.ps1
-    arguments: -WttInputPath '$env:LogPath\MrtUnitTest.wtl' -XUnitOutputPath '$env:LogPath\onBuildMachineResults.xml' -TestNamePrefix '$(BuildConfiguration).$(BuildPlatform)' -HelixWorkItem 0
-  env:
-    LogPath: ${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)\UnitTest
-  condition: or(eq(variables['BuildPlatform'], 'x64'), eq(variables['BuildPlatform'], 'x86'))
+# - task: PowerShell@2
+#   displayName: 'Convert Test Logs from WTL to xUnit format'
+#   inputs:
+#     targetType: filePath
+#     filePath: build\Helix\ConvertWttLogToXUnit.ps1
+#     arguments: -WttInputPath '$env:LogPath\MrtUnitTest.wtl' -XUnitOutputPath '$env:LogPath\onBuildMachineResults.xml' -TestNamePrefix '$(BuildConfiguration).$(BuildPlatform)' -HelixWorkItem 0
+#   env:
+#     LogPath: ${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)\UnitTest
+#   condition: or(eq(variables['BuildPlatform'], 'x64'), eq(variables['BuildPlatform'], 'x86'))
 
-- task: PublishTestResults@2
-  displayName: 'Upload converted test logs'
-  inputs:
-    testResultsFormat: 'xUnit'
-    testResultsFiles: '**/onBuildMachineResults.xml' 
-    searchFolder: '${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)'
-    testRunTitle: 'test MRT - On Build Machine Tests'
-    buildPlatform: $(BuildPlatform)
-    buildConfiguration: $(BuildConfiguration)
-  condition: or(eq(variables['BuildPlatform'], 'x64'), eq(variables['BuildPlatform'], 'x86'))
+# - task: PublishTestResults@2
+#   displayName: 'Upload converted test logs'
+#   inputs:
+#     testResultsFormat: 'xUnit'
+#     testResultsFiles: '**/onBuildMachineResults.xml' 
+#     searchFolder: '${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)'
+#     testRunTitle: 'test MRT - On Build Machine Tests'
+#     buildPlatform: $(BuildPlatform)
+#     buildConfiguration: $(BuildConfiguration)
+#   condition: or(eq(variables['BuildPlatform'], 'x64'), eq(variables['BuildPlatform'], 'x86'))
 
-- task: CopyFiles@2
-  displayName: 'test MRT - Copy test logs for Artifacts'
-  inputs:
-    Contents: |
-     **/*.wtl
-     **/*onBuildMachineResults.xml
-    TargetFolder: '$(Build.ArtifactStagingDirectory)\mrt_test\$(buildConfiguration)\$(buildPlatform)'
-    OverWrite: true
-    flattenFolders: true
-  condition: or(eq(variables['BuildPlatform'], 'x64'), eq(variables['BuildPlatform'], 'x86'))
+# - task: CopyFiles@2
+#   displayName: 'test MRT - Copy test logs for Artifacts'
+#   inputs:
+#     Contents: |
+#      **/*.wtl
+#      **/*onBuildMachineResults.xml
+#     TargetFolder: '$(Build.ArtifactStagingDirectory)\mrt_test\$(buildConfiguration)\$(buildPlatform)'
+#     OverWrite: true
+#     flattenFolders: true
+#   condition: or(eq(variables['BuildPlatform'], 'x64'), eq(variables['BuildPlatform'], 'x86'))
 
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish Artifact: MRT Test results'
-  inputs:
-    PathtoPublish: '$(Build.ArtifactStagingDirectory)\mrt_test'
-    ArtifactName: 'mrtcore_test'
-  condition: or(eq(variables['BuildPlatform'], 'x64'), eq(variables['BuildPlatform'], 'x86'))
+# - task: PublishBuildArtifacts@1
+#   displayName: 'Publish Artifact: MRT Test results'
+#   inputs:
+#     PathtoPublish: '$(Build.ArtifactStagingDirectory)\mrt_test'
+#     ArtifactName: 'mrtcore_test'
+#   condition: or(eq(variables['BuildPlatform'], 'x64'), eq(variables['BuildPlatform'], 'x86'))
 
 - task: VSTest@2
   displayName: 'test MRT'
@@ -194,7 +194,6 @@ steps:
       !**\TE.*.dll
       !**\obj\**
       !**\MrtCoreUnpackagedTests.dll
-      !**\Unittest.dll
     searchFolder: '${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)'
     testRunTitle: 'test MRT $(buildPlatform)'
     platform: '$(buildPlatform)'

--- a/build/build-mrt.yml
+++ b/build/build-mrt.yml
@@ -151,7 +151,7 @@ steps:
   inputs:
     targetType: filePath
     filePath: build\Helix\ConvertWttLogToXUnit.ps1
-    arguments: -WttInputPath '${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)\UnitTest\MrtUnitTest.wtl' -WttSingleRerunInputPath 'unused.wtl' -WttMultipleRerunInputPath 'unused2.wtl' -XUnitOutputPath 'onBuildMachineResults.xml' -TestNamePrefix '$(BuildConfiguration).$(BuildPlatform)'
+    arguments: -WttInputPath '${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)\UnitTest\MrtUnitTest.wtl' -XUnitOutputPath 'onBuildMachineResults.xml' -TestNamePrefix '$(BuildConfiguration).$(BuildPlatform)' -HelixWorkItem 0
   condition: or(eq(variables['BuildPlatform'], 'x64'), eq(variables['BuildPlatform'], 'x86'))
 
 - task: PublishTestResults@2

--- a/build/build-mrt.yml
+++ b/build/build-mrt.yml
@@ -135,6 +135,51 @@ steps:
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
 
+- task: CmdLine@2
+  displayName: 'test MRT - UnitTest'
+  inputs:
+    script: |
+      echo te.exe UnitTest.dll /enablewttlogging /appendwttlogging /logFile:%LogPath%
+      te.exe UnitTest.dll /enablewttlogging /appendwttlogging /logFile:%LogPath%
+    workingDirectory: '${{ parameters.MRTBinariesDirectory }}\($buildConfiguration)\$(buildPlatform)\UnitTest'
+  env:
+    LogPath: ${{ parameters.MRTBinariesDirectory }}\($buildConfiguration)\$(buildPlatform)\UnitTest\MrtUnitTest.wtl
+  condition: or(eq(variables.buildPlatform, 'x64'), eq(variables.buildPlatform, 'x86'))
+
+- task: PowerShell@2
+  displayName: 'Convert Test Logs from WTL to xUnit format'
+  inputs:
+    targetType: filePath
+    filePath: build\Helix\ConvertWttLogToXUnit.ps1
+    arguments: -WttInputPath $LogPath -WttSingleRerunInputPath 'unused.wtl' -WttMultipleRerunInputPath 'unused2.wtl' -XUnitOutputPath 'onBuildMachineResults.xml' -TestNamePrefix '$(BuildConfiguration).$(BuildPlatform)'
+  env:
+    LogPath: ${{ parameters.MRTBinariesDirectory }}\($buildConfiguration)\$(buildPlatform)\UnitTest\MrtUnitTest.wtl
+  condition: or(eq(variables['BuildPlatform'], 'x64'), eq(variables['BuildPlatform'], 'x86'))
+
+- task: PublishTestResults@2
+  displayName: 'Upload converted test logs'
+  inputs:
+    testResultsFormat: 'xUnit' # Options: JUnit, NUnit, VSTest, xUnit, cTest
+    testResultsFiles: '**/onBuildMachineResults.xml' 
+    searchFolder: '${{ parameters.MRTBinariesDirectory }}\($buildConfiguration)\$(buildPlatform)'
+    #mergeTestResults: false # Optional
+    #failTaskOnFailedTests: false # Optional
+    testRunTitle: 'test MRT - On Build Machine Tests' # Optional
+    buildPlatform: $(BuildPlatform) # Optional
+    buildConfiguration: $(BuildConfiguration) # Optional
+    #publishRunAttachments: true # Optional
+
+- task: CopyFiles@2
+  displayName: 'test MRT - Copy result logs to Artifacts'
+  inputs:
+    Contents: |
+     **/*.wtl
+     **/*onBuildMachineResults.xml
+     ${{ parameters.MRTBinariesDirectory }}\($buildConfiguration)\$(buildPlatform)\UnitTest\MrtUnitTest.wtl
+    TargetFolder: '$(Build.ArtifactStagingDirectory)\mrt_test\($buildConfiguration)\$(buildPlatform)'
+    OverWrite: true
+    flattenFolders: true
+
 - task: VSTest@2
   displayName: 'test MRT'
   condition: and(succeeded(), or(eq(variables['buildPlatform'], 'x86'), eq(variables['buildPlatform'], 'x64')))
@@ -146,7 +191,8 @@ steps:
       !**\TE.*.dll
       !**\obj\**
       !**\MrtCoreUnpackagedTests.dll
-    searchFolder: '${{ parameters.MRTBinariesDirectory }}\Release\$(buildPlatform)'
+      !**\Unittest.dll
+    searchFolder: '${{ parameters.MRTBinariesDirectory }}\($buildConfiguration)\$(buildPlatform)'
     testRunTitle: 'test MRT $(buildPlatform)'
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
@@ -197,3 +243,9 @@ steps:
   inputs:
     PathtoPublish: '$(Build.ArtifactStagingDirectory)\mrt_raw'
     ArtifactName: 'mrtcore_binaries'
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish Artifact: MRT Test results'
+  inputs:
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)\mrt_test'
+    ArtifactName: 'mrtcore_test'

--- a/build/build-mrt.yml
+++ b/build/build-mrt.yml
@@ -135,54 +135,6 @@ steps:
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
 
-# - task: CmdLine@2
-#   displayName: 'test MRT - UnitTest'
-#   inputs:
-#     script: te.exe UnitTest.dll /enablewttlogging /appendwttlogging /logFile:%LogPath%
-#     workingDirectory: '${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)\UnitTest'
-#   env:
-#     LogPath: ${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)\UnitTest\MrtUnitTest.wtl
-#   condition: or(eq(variables.buildPlatform, 'x64'), eq(variables.buildPlatform, 'x86'))
-
-# - task: PowerShell@2
-#   displayName: 'Convert Test Logs from WTL to xUnit format'
-#   inputs:
-#     targetType: filePath
-#     filePath: build\Helix\ConvertWttLogToXUnit.ps1
-#     arguments: -WttInputPath '$env:LogPath\MrtUnitTest.wtl' -XUnitOutputPath '$env:LogPath\onBuildMachineResults.xml' -TestNamePrefix '$(BuildConfiguration).$(BuildPlatform)' -HelixWorkItem 0
-#   env:
-#     LogPath: ${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)\UnitTest
-#   condition: or(eq(variables['BuildPlatform'], 'x64'), eq(variables['BuildPlatform'], 'x86'))
-
-# - task: PublishTestResults@2
-#   displayName: 'Upload converted test logs'
-#   inputs:
-#     testResultsFormat: 'xUnit'
-#     testResultsFiles: '**/onBuildMachineResults.xml' 
-#     searchFolder: '${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)'
-#     testRunTitle: 'test MRT - On Build Machine Tests'
-#     buildPlatform: $(BuildPlatform)
-#     buildConfiguration: $(BuildConfiguration)
-#   condition: or(eq(variables['BuildPlatform'], 'x64'), eq(variables['BuildPlatform'], 'x86'))
-
-# - task: CopyFiles@2
-#   displayName: 'test MRT - Copy test logs for Artifacts'
-#   inputs:
-#     Contents: |
-#      **/*.wtl
-#      **/*onBuildMachineResults.xml
-#     TargetFolder: '$(Build.ArtifactStagingDirectory)\mrt_test\$(buildConfiguration)\$(buildPlatform)'
-#     OverWrite: true
-#     flattenFolders: true
-#   condition: or(eq(variables['BuildPlatform'], 'x64'), eq(variables['BuildPlatform'], 'x86'))
-
-# - task: PublishBuildArtifacts@1
-#   displayName: 'Publish Artifact: MRT Test results'
-#   inputs:
-#     PathtoPublish: '$(Build.ArtifactStagingDirectory)\mrt_test'
-#     ArtifactName: 'mrtcore_test'
-#   condition: or(eq(variables['BuildPlatform'], 'x64'), eq(variables['BuildPlatform'], 'x86'))
-
 - task: VSTest@2
   displayName: 'test MRT'
   condition: and(succeeded(), or(eq(variables['buildPlatform'], 'x86'), eq(variables['buildPlatform'], 'x64')))

--- a/build/build-mrt.yml
+++ b/build/build-mrt.yml
@@ -150,9 +150,7 @@ steps:
   inputs:
     targetType: filePath
     filePath: build\Helix\ConvertWttLogToXUnit.ps1
-    arguments: -WttInputPath '$(LogPath)\MrtUnitTest.wtl' -XUnitOutputPath '$(LogPath)\onBuildMachineResults.xml' -TestNamePrefix 'MRTCore.UnitTest.$(BuildConfiguration).$(BuildPlatform)' -HelixWorkItem 0
-  env:
-    LogPath: ${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)\UnitTest
+    arguments: -WttInputPath '${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)\UnitTest\MrtUnitTest.wtl' -XUnitOutputPath '${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)\UnitTest\onBuildMachineResults.xml' -TestNamePrefix 'MRTCore.UnitTest.$(BuildConfiguration).$(BuildPlatform)' -HelixWorkItem 0
   condition: or(eq(variables['BuildPlatform'], 'x64'), eq(variables['BuildPlatform'], 'x86'))
 
 - task: PublishTestResults@2
@@ -170,7 +168,7 @@ steps:
   condition: or(eq(variables['BuildPlatform'], 'x64'), eq(variables['BuildPlatform'], 'x86'))
 
 - task: CopyFiles@2
-  displayName: 'test MRT - Copy test result logs for Artifacts'
+  displayName: 'test MRT - Copy test logs for Artifacts'
   inputs:
     Contents: |
      **/*.wtl
@@ -178,6 +176,13 @@ steps:
     TargetFolder: '$(Build.ArtifactStagingDirectory)\mrt_test\$(buildConfiguration)\$(buildPlatform)'
     OverWrite: true
     flattenFolders: true
+  condition: or(eq(variables['BuildPlatform'], 'x64'), eq(variables['BuildPlatform'], 'x86'))
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish Artifact: MRT Test results'
+  inputs:
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)\mrt_test'
+    ArtifactName: 'mrtcore_test'
   condition: or(eq(variables['BuildPlatform'], 'x64'), eq(variables['BuildPlatform'], 'x86'))
 
 - task: VSTest@2
@@ -243,10 +248,3 @@ steps:
   inputs:
     PathtoPublish: '$(Build.ArtifactStagingDirectory)\mrt_raw'
     ArtifactName: 'mrtcore_binaries'
-
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish Artifact: MRT Test results'
-  inputs:
-    PathtoPublish: '$(Build.ArtifactStagingDirectory)\mrt_test'
-    ArtifactName: 'mrtcore_test'
-  condition: or(eq(variables['BuildPlatform'], 'x64'), eq(variables['BuildPlatform'], 'x86'))

--- a/build/build-mrt.yml
+++ b/build/build-mrt.yml
@@ -138,8 +138,7 @@ steps:
 - task: CmdLine@2
   displayName: 'test MRT - UnitTest'
   inputs:
-    script: |
-      te.exe UnitTest.dll /enablewttlogging /appendwttlogging /logFile:%LogPath%
+    script: te.exe UnitTest.dll /enablewttlogging /appendwttlogging /logFile:%LogPath%
     workingDirectory: '${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)\UnitTest'
   env:
     LogPath: ${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)\UnitTest\MrtUnitTest.wtl
@@ -150,21 +149,20 @@ steps:
   inputs:
     targetType: filePath
     filePath: build\Helix\ConvertWttLogToXUnit.ps1
-    arguments: -WttInputPath '${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)\UnitTest\MrtUnitTest.wtl' -XUnitOutputPath '${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)\UnitTest\onBuildMachineResults.xml' -TestNamePrefix '$(BuildConfiguration).$(BuildPlatform)' -HelixWorkItem 0
+    arguments: -WttInputPath '$env:LogPath\MrtUnitTest.wtl' -XUnitOutputPath '$env:LogPath\onBuildMachineResults.xml' -TestNamePrefix '$(BuildConfiguration).$(BuildPlatform)' -HelixWorkItem 0
+  env:
+    LogPath: ${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)\UnitTest
   condition: or(eq(variables['BuildPlatform'], 'x64'), eq(variables['BuildPlatform'], 'x86'))
 
 - task: PublishTestResults@2
   displayName: 'Upload converted test logs'
   inputs:
-    testResultsFormat: 'xUnit' # Options: JUnit, NUnit, VSTest, xUnit, cTest
+    testResultsFormat: 'xUnit'
     testResultsFiles: '**/onBuildMachineResults.xml' 
     searchFolder: '${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)'
-    #mergeTestResults: false # Optional
-    #failTaskOnFailedTests: false # Optional
-    testRunTitle: 'test MRT - On Build Machine Tests' # Optional
-    buildPlatform: $(BuildPlatform) # Optional
-    buildConfiguration: $(BuildConfiguration) # Optional
-    #publishRunAttachments: true # Optional
+    testRunTitle: 'test MRT - On Build Machine Tests'
+    buildPlatform: $(BuildPlatform)
+    buildConfiguration: $(BuildConfiguration)
   condition: or(eq(variables['BuildPlatform'], 'x64'), eq(variables['BuildPlatform'], 'x86'))
 
 - task: CopyFiles@2

--- a/build/build-mrt.yml
+++ b/build/build-mrt.yml
@@ -141,9 +141,9 @@ steps:
     script: |
       echo te.exe UnitTest.dll /enablewttlogging /appendwttlogging /logFile:%LogPath%
       te.exe UnitTest.dll /enablewttlogging /appendwttlogging /logFile:%LogPath%
-    workingDirectory: '${{ parameters.MRTBinariesDirectory }}\($buildConfiguration)\$(buildPlatform)\UnitTest'
+    workingDirectory: '${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)\UnitTest'
   env:
-    LogPath: ${{ parameters.MRTBinariesDirectory }}\($buildConfiguration)\$(buildPlatform)\UnitTest\MrtUnitTest.wtl
+    LogPath: ${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)\UnitTest\MrtUnitTest.wtl
   condition: or(eq(variables.buildPlatform, 'x64'), eq(variables.buildPlatform, 'x86'))
 
 - task: PowerShell@2
@@ -153,7 +153,7 @@ steps:
     filePath: build\Helix\ConvertWttLogToXUnit.ps1
     arguments: -WttInputPath $LogPath -WttSingleRerunInputPath 'unused.wtl' -WttMultipleRerunInputPath 'unused2.wtl' -XUnitOutputPath 'onBuildMachineResults.xml' -TestNamePrefix '$(BuildConfiguration).$(BuildPlatform)'
   env:
-    LogPath: ${{ parameters.MRTBinariesDirectory }}\($buildConfiguration)\$(buildPlatform)\UnitTest\MrtUnitTest.wtl
+    LogPath: ${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)\UnitTest\MrtUnitTest.wtl
   condition: or(eq(variables['BuildPlatform'], 'x64'), eq(variables['BuildPlatform'], 'x86'))
 
 - task: PublishTestResults@2
@@ -161,13 +161,14 @@ steps:
   inputs:
     testResultsFormat: 'xUnit' # Options: JUnit, NUnit, VSTest, xUnit, cTest
     testResultsFiles: '**/onBuildMachineResults.xml' 
-    searchFolder: '${{ parameters.MRTBinariesDirectory }}\($buildConfiguration)\$(buildPlatform)'
+    searchFolder: '${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)'
     #mergeTestResults: false # Optional
     #failTaskOnFailedTests: false # Optional
     testRunTitle: 'test MRT - On Build Machine Tests' # Optional
     buildPlatform: $(BuildPlatform) # Optional
     buildConfiguration: $(BuildConfiguration) # Optional
     #publishRunAttachments: true # Optional
+  condition: or(eq(variables['BuildPlatform'], 'x64'), eq(variables['BuildPlatform'], 'x86'))
 
 - task: CopyFiles@2
   displayName: 'test MRT - Copy result logs to Artifacts'
@@ -175,10 +176,11 @@ steps:
     Contents: |
      **/*.wtl
      **/*onBuildMachineResults.xml
-     ${{ parameters.MRTBinariesDirectory }}\($buildConfiguration)\$(buildPlatform)\UnitTest\MrtUnitTest.wtl
-    TargetFolder: '$(Build.ArtifactStagingDirectory)\mrt_test\($buildConfiguration)\$(buildPlatform)'
+     ${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)\UnitTest\MrtUnitTest.wtl
+    TargetFolder: '$(Build.ArtifactStagingDirectory)\mrt_test\$(buildConfiguration)\$(buildPlatform)'
     OverWrite: true
     flattenFolders: true
+  condition: or(eq(variables['BuildPlatform'], 'x64'), eq(variables['BuildPlatform'], 'x86'))
 
 - task: VSTest@2
   displayName: 'test MRT'
@@ -192,7 +194,7 @@ steps:
       !**\obj\**
       !**\MrtCoreUnpackagedTests.dll
       !**\Unittest.dll
-    searchFolder: '${{ parameters.MRTBinariesDirectory }}\($buildConfiguration)\$(buildPlatform)'
+    searchFolder: '${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)'
     testRunTitle: 'test MRT $(buildPlatform)'
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'

--- a/build/build-mrt.yml
+++ b/build/build-mrt.yml
@@ -139,7 +139,6 @@ steps:
   displayName: 'test MRT - UnitTest'
   inputs:
     script: |
-      echo te.exe UnitTest.dll /enablewttlogging /appendwttlogging /logFile:%LogPath%
       te.exe UnitTest.dll /enablewttlogging /appendwttlogging /logFile:%LogPath%
     workingDirectory: '${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)\UnitTest'
   env:
@@ -151,7 +150,9 @@ steps:
   inputs:
     targetType: filePath
     filePath: build\Helix\ConvertWttLogToXUnit.ps1
-    arguments: -WttInputPath '${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)\UnitTest\MrtUnitTest.wtl' -XUnitOutputPath 'onBuildMachineResults.xml' -TestNamePrefix '$(BuildConfiguration).$(BuildPlatform)' -HelixWorkItem 0
+    arguments: -WttInputPath '$(LogPath)\MrtUnitTest.wtl' -XUnitOutputPath '$(LogPath)\onBuildMachineResults.xml' -TestNamePrefix 'MRTCore.UnitTest.$(BuildConfiguration).$(BuildPlatform)' -HelixWorkItem 0
+  env:
+    LogPath: ${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)\UnitTest
   condition: or(eq(variables['BuildPlatform'], 'x64'), eq(variables['BuildPlatform'], 'x86'))
 
 - task: PublishTestResults@2
@@ -162,19 +163,18 @@ steps:
     searchFolder: '${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)'
     #mergeTestResults: false # Optional
     #failTaskOnFailedTests: false # Optional
-    testRunTitle: 'test MRT - On Build Machine Tests' # Optional
+    testRunTitle: 'test MRT - On Build Machine' # Optional
     buildPlatform: $(BuildPlatform) # Optional
     buildConfiguration: $(BuildConfiguration) # Optional
     #publishRunAttachments: true # Optional
   condition: or(eq(variables['BuildPlatform'], 'x64'), eq(variables['BuildPlatform'], 'x86'))
 
 - task: CopyFiles@2
-  displayName: 'test MRT - Copy result logs to Artifacts'
+  displayName: 'test MRT - Copy test result logs for Artifacts'
   inputs:
     Contents: |
      **/*.wtl
      **/*onBuildMachineResults.xml
-     ${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)\UnitTest\MrtUnitTest.wtl
     TargetFolder: '$(Build.ArtifactStagingDirectory)\mrt_test\$(buildConfiguration)\$(buildPlatform)'
     OverWrite: true
     flattenFolders: true

--- a/build/build-mrt.yml
+++ b/build/build-mrt.yml
@@ -150,7 +150,7 @@ steps:
   inputs:
     targetType: filePath
     filePath: build\Helix\ConvertWttLogToXUnit.ps1
-    arguments: -WttInputPath '${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)\UnitTest\MrtUnitTest.wtl' -XUnitOutputPath '${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)\UnitTest\onBuildMachineResults.xml' -TestNamePrefix 'MRTCore.UnitTest.$(BuildConfiguration).$(BuildPlatform)' -HelixWorkItem 0
+    arguments: -WttInputPath '${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)\UnitTest\MrtUnitTest.wtl' -XUnitOutputPath '${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)\UnitTest\onBuildMachineResults.xml' -TestNamePrefix '$(BuildConfiguration).$(BuildPlatform)' -HelixWorkItem 0
   condition: or(eq(variables['BuildPlatform'], 'x64'), eq(variables['BuildPlatform'], 'x86'))
 
 - task: PublishTestResults@2
@@ -161,7 +161,7 @@ steps:
     searchFolder: '${{ parameters.MRTBinariesDirectory }}\$(buildConfiguration)\$(buildPlatform)'
     #mergeTestResults: false # Optional
     #failTaskOnFailedTests: false # Optional
-    testRunTitle: 'test MRT - On Build Machine' # Optional
+    testRunTitle: 'test MRT - On Build Machine Tests' # Optional
     buildPlatform: $(BuildPlatform) # Optional
     buildConfiguration: $(BuildConfiguration) # Optional
     #publishRunAttachments: true # Optional

--- a/dev/MRTCore/mrt/Core/unittests/MrmTests.cpp
+++ b/dev/MRTCore/mrt/Core/unittests/MrmTests.cpp
@@ -18,6 +18,10 @@ public:
 
     TEST_METHOD(ReadResourceString)
     {
+        wchar_t path[MAX_PATH] = {};
+        VERIFY_WIN32_BOOL_SUCCEEDED(GetCurrentDirectory(ARRAYSIZE(path), path));
+        WEX::Logging::Log::Comment(WEX::Common::String().Format(L"Current directory: %s", path));
+
         MrmManagerHandle resourceManager;
         VERIFY_ARE_EQUAL(MrmCreateResourceManager(L".\\resources.pri", &resourceManager), S_OK);
 

--- a/dev/MRTCore/mrt/Core/unittests/MrmTests.cpp
+++ b/dev/MRTCore/mrt/Core/unittests/MrmTests.cpp
@@ -2,26 +2,29 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #include <Windows.h>
+#include <WexTestClass.h>
 #include "..\src\MRM.h"
 
-#include "CppUnitTest.h"
-using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+using namespace WEX::Common;
+using namespace WEX::TestExecution;
+using namespace WEX::Logging;
 
 namespace UnitTest
 {
-
-TEST_CLASS(BasicTest)
+class BasicTest
 {
 public:
+    TEST_CLASS(BasicTest);
+
     TEST_METHOD(ReadResourceString)
     {
         MrmManagerHandle resourceManager;
-        Assert::AreEqual(MrmCreateResourceManager(L".\\resources.pri", &resourceManager), S_OK);
+        VERIFY_ARE_EQUAL(MrmCreateResourceManager(L".\\resources.pri", &resourceManager), S_OK);
 
         wchar_t* resourceString;
-        Assert::AreEqual(MrmLoadStringResource(resourceManager, nullptr, nullptr, L"resources/IDS_MANIFEST_MUSIC_APP_NAME", &resourceString), S_OK);
+        VERIFY_ARE_EQUAL(MrmLoadStringResource(resourceManager, nullptr, nullptr, L"resources/IDS_MANIFEST_MUSIC_APP_NAME", &resourceString), S_OK);
 
-        Assert::AreEqual(resourceString, L"Groove Music");
+        VERIFY_ARE_EQUAL(resourceString, L"Groove Music");
 
         MrmFreeResource(resourceString);
         MrmDestroyResourceManager(resourceManager);
@@ -30,18 +33,18 @@ public:
     TEST_METHOD(ReadResourceStringWithResourceMap)
     {
         MrmManagerHandle resourceManager;
-        Assert::AreEqual(MrmCreateResourceManager(L".\\resources.pri", &resourceManager), S_OK);
+        VERIFY_ARE_EQUAL(MrmCreateResourceManager(L".\\resources.pri", &resourceManager), S_OK);
 
         MrmMapHandle childResourceMap;
-        Assert::AreEqual(MrmGetChildResourceMap(resourceManager, nullptr, L"Microsoft.UI.Xaml", &childResourceMap), S_OK);
+        VERIFY_ARE_EQUAL(MrmGetChildResourceMap(resourceManager, nullptr, L"Microsoft.UI.Xaml", &childResourceMap), S_OK);
 
         MrmMapHandle childChildResourceMap;
-        Assert::AreEqual(MrmGetChildResourceMap(resourceManager, childResourceMap, L"Resources", &childChildResourceMap), S_OK);
+        VERIFY_ARE_EQUAL(MrmGetChildResourceMap(resourceManager, childResourceMap, L"Resources", &childChildResourceMap), S_OK);
 
         wchar_t* resourceString;
-        Assert::AreEqual(MrmLoadStringResource(resourceManager, nullptr, childChildResourceMap, L"HelpTextMoreButton", &resourceString), S_OK);
+        VERIFY_ARE_EQUAL(MrmLoadStringResource(resourceManager, nullptr, childChildResourceMap, L"HelpTextMoreButton", &resourceString), S_OK);
 
-        Assert::AreEqual(resourceString, L"Invoke to show or hide the text entry fields.");
+        VERIFY_ARE_EQUAL(resourceString, L"Invoke to show or hide the text entry fields.");
 
         MrmFreeResource(resourceString);
         MrmDestroyResourceManager(resourceManager);
@@ -50,12 +53,12 @@ public:
     TEST_METHOD(ReadResourceStringFromFullUri)
     {
         MrmManagerHandle resourceManager;
-        Assert::AreEqual(MrmCreateResourceManager(L".\\resources.pri", &resourceManager), S_OK);
+        VERIFY_ARE_EQUAL(MrmCreateResourceManager(L".\\resources.pri", &resourceManager), S_OK);
 
         wchar_t* resourceString;
-        Assert::AreEqual(MrmLoadStringResourceFromResourceUri(resourceManager, nullptr, L"ms-resource://Microsoft.ZuneMusic/resources/IDS_MANIFEST_MUSIC_APP_NAME", &resourceString), S_OK);
+        VERIFY_ARE_EQUAL(MrmLoadStringResourceFromResourceUri(resourceManager, nullptr, L"ms-resource://Microsoft.ZuneMusic/resources/IDS_MANIFEST_MUSIC_APP_NAME", &resourceString), S_OK);
 
-        Assert::AreEqual(resourceString, L"Groove Music");
+        VERIFY_ARE_EQUAL(resourceString, L"Groove Music");
 
         MrmFreeResource(resourceString);
         MrmDestroyResourceManager(resourceManager);
@@ -64,12 +67,12 @@ public:
     TEST_METHOD(ReadResourceStringFromFullUri_ImplicitResourceMap)
     {
         MrmManagerHandle resourceManager;
-        Assert::AreEqual(MrmCreateResourceManager(L".\\resources.pri", &resourceManager), S_OK);
+        VERIFY_ARE_EQUAL(MrmCreateResourceManager(L".\\resources.pri", &resourceManager), S_OK);
 
         wchar_t* resourceString;
-        Assert::AreEqual(MrmLoadStringResourceFromResourceUri(resourceManager, nullptr, L"ms-resource:///resources/IDS_MANIFEST_MUSIC_APP_NAME", &resourceString), S_OK);
+        VERIFY_ARE_EQUAL(MrmLoadStringResourceFromResourceUri(resourceManager, nullptr, L"ms-resource:///resources/IDS_MANIFEST_MUSIC_APP_NAME", &resourceString), S_OK);
 
-        Assert::AreEqual(resourceString, L"Groove Music");
+        VERIFY_ARE_EQUAL(resourceString, L"Groove Music");
 
         MrmFreeResource(resourceString);
         MrmDestroyResourceManager(resourceManager);
@@ -78,21 +81,21 @@ public:
     TEST_METHOD(ReadResourceStringFromFullUri_InvalidUri)
     {
         MrmManagerHandle resourceManager;
-        Assert::AreEqual(MrmCreateResourceManager(L".\\resources.pri", &resourceManager), S_OK);
+        VERIFY_ARE_EQUAL(MrmCreateResourceManager(L".\\resources.pri", &resourceManager), S_OK);
 
         wchar_t* resourceString;
 
-        Assert::AreEqual(MrmLoadStringResourceFromResourceUri(resourceManager, nullptr, L"ms-resource://", &resourceString), E_INVALIDARG);
+        VERIFY_ARE_EQUAL(MrmLoadStringResourceFromResourceUri(resourceManager, nullptr, L"ms-resource://", &resourceString), E_INVALIDARG);
 
-        Assert::AreEqual(MrmLoadStringResourceFromResourceUri(resourceManager, nullptr, L"ms-resource:///", &resourceString), E_INVALIDARG);
+        VERIFY_ARE_EQUAL(MrmLoadStringResourceFromResourceUri(resourceManager, nullptr, L"ms-resource:///", &resourceString), E_INVALIDARG);
 
-        Assert::AreEqual(MrmLoadStringResourceFromResourceUri(resourceManager, nullptr, L"ms-resource:///abc", &resourceString), HRESULT_FROM_WIN32(ERROR_MRM_NAMED_RESOURCE_NOT_FOUND));
+        VERIFY_ARE_EQUAL(MrmLoadStringResourceFromResourceUri(resourceManager, nullptr, L"ms-resource:///abc", &resourceString), HRESULT_FROM_WIN32(ERROR_MRM_NAMED_RESOURCE_NOT_FOUND));
 
-        Assert::AreEqual(MrmLoadStringResourceFromResourceUri(resourceManager, nullptr, L"ms-resource://abc", &resourceString), E_INVALIDARG);
+        VERIFY_ARE_EQUAL(MrmLoadStringResourceFromResourceUri(resourceManager, nullptr, L"ms-resource://abc", &resourceString), E_INVALIDARG);
 
-        Assert::AreEqual(MrmLoadStringResourceFromResourceUri(resourceManager, nullptr, L"ms-resource://Microsoft.ZuneMusic/abc", &resourceString), HRESULT_FROM_WIN32(ERROR_MRM_NAMED_RESOURCE_NOT_FOUND));
+        VERIFY_ARE_EQUAL(MrmLoadStringResourceFromResourceUri(resourceManager, nullptr, L"ms-resource://Microsoft.ZuneMusic/abc", &resourceString), HRESULT_FROM_WIN32(ERROR_MRM_NAMED_RESOURCE_NOT_FOUND));
 
-        Assert::AreEqual(
+        VERIFY_ARE_EQUAL(
             MrmLoadStringResourceFromResourceUri(
                 resourceManager,
                 nullptr,
@@ -109,53 +112,53 @@ public:
     TEST_METHOD(ReadResourceStringWithQualifierOverride)
     {
         MrmManagerHandle resourceManager;
-        Assert::AreEqual(MrmCreateResourceManager(L".\\resources.pri", &resourceManager), S_OK);
+        VERIFY_ARE_EQUAL(MrmCreateResourceManager(L".\\resources.pri", &resourceManager), S_OK);
 
         MrmContextHandle resourceContext;
-        Assert::AreEqual(MrmCreateResourceContext(resourceManager, &resourceContext), S_OK);
+        VERIFY_ARE_EQUAL(MrmCreateResourceContext(resourceManager, &resourceContext), S_OK);
 
         PWSTR* qualifierNames = nullptr;
         UINT32 size = 0;
-        Assert::AreEqual(MrmGetAllQualifierNames(resourceContext, &size, &qualifierNames), S_OK);
+        VERIFY_ARE_EQUAL(MrmGetAllQualifierNames(resourceContext, &size, &qualifierNames), S_OK);
 
         // We currently support 12 qualifiers defined in MrmConstants.h
-        Assert::AreEqual(size, 12u);
-        Assert::AreEqual(*qualifierNames, L"Language");
-        Assert::AreEqual(*(qualifierNames + 11), L"Custom");
+        VERIFY_ARE_EQUAL(size, 12u);
+        VERIFY_ARE_EQUAL(*qualifierNames, L"Language");
+        VERIFY_ARE_EQUAL(*(qualifierNames + 11), L"Custom");
 
         MrmFreeQualifierNamesOrValues(size, qualifierNames);
 
         {
-            Assert::AreEqual(MrmSetQualifier(resourceContext, L"Contrast", L"WHITE"), S_OK);
-            Assert::AreEqual(MrmSetQualifier(resourceContext, L"TargetSize", L"96"), S_OK);
+            VERIFY_ARE_EQUAL(MrmSetQualifier(resourceContext, L"Contrast", L"WHITE"), S_OK);
+            VERIFY_ARE_EQUAL(MrmSetQualifier(resourceContext, L"TargetSize", L"96"), S_OK);
 
             wchar_t* resourceString;
-            Assert::AreEqual(MrmLoadStringResource(resourceManager, resourceContext, nullptr, L"Files/Assets/AppList.png", &resourceString), S_OK);
+            VERIFY_ARE_EQUAL(MrmLoadStringResource(resourceManager, resourceContext, nullptr, L"Files/Assets/AppList.png", &resourceString), S_OK);
 
             // File resources have the path of the PRI file prepended to turn them into fully qualified paths.
-            Assert::IsNotNull(wcsstr(resourceString, L"Assets\\contrast-white\\AppList.targetsize-96_contrast-white.png"));
+            VERIFY_IS_NOT_NULL(wcsstr(resourceString, L"Assets\\contrast-white\\AppList.targetsize-96_contrast-white.png"));
 
             wchar_t* qualifierValue;
-            Assert::AreEqual(MrmGetQualifier(resourceContext, L"Contrast", &qualifierValue), S_OK);
-            Assert::AreEqual(qualifierValue, L"WHITE");
+            VERIFY_ARE_EQUAL(MrmGetQualifier(resourceContext, L"Contrast", &qualifierValue), S_OK);
+            VERIFY_ARE_EQUAL(qualifierValue, L"WHITE");
             MrmFreeResource(qualifierValue);
 
-            Assert::AreEqual(MrmGetQualifier(resourceContext, L"TargetSize", &qualifierValue), S_OK);
-            Assert::AreEqual(qualifierValue, L"96");
+            VERIFY_ARE_EQUAL(MrmGetQualifier(resourceContext, L"TargetSize", &qualifierValue), S_OK);
+            VERIFY_ARE_EQUAL(qualifierValue, L"96");
             MrmFreeResource(qualifierValue);
 
             MrmFreeResource(resourceString);
         }
 
         {
-            Assert::AreEqual(MrmSetQualifier(resourceContext, L"Contrast", L"BLACK"), S_OK);
-            Assert::AreEqual(MrmSetQualifier(resourceContext, L"TargetSize", L"72"), S_OK);
+            VERIFY_ARE_EQUAL(MrmSetQualifier(resourceContext, L"Contrast", L"BLACK"), S_OK);
+            VERIFY_ARE_EQUAL(MrmSetQualifier(resourceContext, L"TargetSize", L"72"), S_OK);
 
             wchar_t* resourceString;
-            Assert::AreEqual(MrmLoadStringResource(resourceManager, resourceContext, nullptr, L"Files/Assets/AppList.png", &resourceString), S_OK);
+            VERIFY_ARE_EQUAL(MrmLoadStringResource(resourceManager, resourceContext, nullptr, L"Files/Assets/AppList.png", &resourceString), S_OK);
 
             // File resources have the path of the PRI file prepended to turn them into fully qualified paths.
-            Assert::IsNotNull(wcsstr(resourceString, L"Assets\\contrast-black\\AppList.targetsize-72_contrast-black.png"));
+            VERIFY_IS_NOT_NULL(wcsstr(resourceString, L"Assets\\contrast-black\\AppList.targetsize-72_contrast-black.png"));
 
             MrmFreeResource(resourceString);
         }
@@ -167,29 +170,29 @@ public:
     TEST_METHOD(ReadResourceStringWithLanguageQualifier)
     {
         MrmManagerHandle resourceManager;
-        Assert::AreEqual(MrmCreateResourceManager(L".\\resources.pri", &resourceManager), S_OK);
+        VERIFY_ARE_EQUAL(MrmCreateResourceManager(L".\\resources.pri", &resourceManager), S_OK);
 
         MrmContextHandle resourceContext;
-        Assert::AreEqual(MrmCreateResourceContext(resourceManager, &resourceContext), S_OK);
+        VERIFY_ARE_EQUAL(MrmCreateResourceContext(resourceManager, &resourceContext), S_OK);
 
         wchar_t* resourceString;
-        Assert::AreEqual(MrmSetQualifier(resourceContext, L"Language", L"en-US"), S_OK);
-        Assert::AreEqual(MrmLoadStringResource(resourceManager, resourceContext, nullptr, L"resources/IDS_WHATS_NEW_1710_2_EQUALIZER_TITLE", &resourceString), S_OK);
+        VERIFY_ARE_EQUAL(MrmSetQualifier(resourceContext, L"Language", L"en-US"), S_OK);
+        VERIFY_ARE_EQUAL(MrmLoadStringResource(resourceManager, resourceContext, nullptr, L"resources/IDS_WHATS_NEW_1710_2_EQUALIZER_TITLE", &resourceString), S_OK);
 
-        Assert::AreEqual(resourceString, L"Equalizer");
+        VERIFY_ARE_EQUAL(resourceString, L"Equalizer");
         MrmFreeResource(resourceString);
 
-        Assert::AreEqual(MrmSetQualifier(resourceContext, L"Language", L"en-GB"), S_OK);
-        Assert::AreEqual(MrmLoadStringResource(resourceManager, resourceContext, nullptr, L"resources/IDS_WHATS_NEW_1710_2_EQUALIZER_TITLE", &resourceString), S_OK);
+        VERIFY_ARE_EQUAL(MrmSetQualifier(resourceContext, L"Language", L"en-GB"), S_OK);
+        VERIFY_ARE_EQUAL(MrmLoadStringResource(resourceManager, resourceContext, nullptr, L"resources/IDS_WHATS_NEW_1710_2_EQUALIZER_TITLE", &resourceString), S_OK);
 
-        Assert::AreEqual(resourceString, L"Equaliser");
+        VERIFY_ARE_EQUAL(resourceString, L"Equaliser");
         MrmFreeResource(resourceString);
 
         // en-AU is closer to en-GB
-        Assert::AreEqual(MrmSetQualifier(resourceContext, L"Language", L"en-AU"), S_OK);
-        Assert::AreEqual(MrmLoadStringResource(resourceManager, resourceContext, nullptr, L"resources/IDS_WHATS_NEW_1710_2_EQUALIZER_TITLE", &resourceString), S_OK);
+        VERIFY_ARE_EQUAL(MrmSetQualifier(resourceContext, L"Language", L"en-AU"), S_OK);
+        VERIFY_ARE_EQUAL(MrmLoadStringResource(resourceManager, resourceContext, nullptr, L"resources/IDS_WHATS_NEW_1710_2_EQUALIZER_TITLE", &resourceString), S_OK);
 
-        Assert::AreEqual(resourceString, L"Equaliser");
+        VERIFY_ARE_EQUAL(resourceString, L"Equaliser");
         MrmFreeResource(resourceString);
 
         MrmDestroyResourceManager(resourceManager);
@@ -198,12 +201,12 @@ public:
     TEST_METHOD(ReadEmbeddedResourceFromFullUri)
     {
         MrmManagerHandle resourceManager;
-        Assert::AreEqual(MrmCreateResourceManager(L".\\resources.pri", &resourceManager), S_OK);
+        VERIFY_ARE_EQUAL(MrmCreateResourceManager(L".\\resources.pri", &resourceManager), S_OK);
 
         MrmResourceData resourceData {};
-        Assert::AreEqual(MrmLoadEmbeddedResourceFromResourceUri(resourceManager, nullptr, L"ms-resource://Microsoft.ZuneMusic/Files/Controls/AlbumBasicInfoControl.xbf", &resourceData), S_OK);
+        VERIFY_ARE_EQUAL(MrmLoadEmbeddedResourceFromResourceUri(resourceManager, nullptr, L"ms-resource://Microsoft.ZuneMusic/Files/Controls/AlbumBasicInfoControl.xbf", &resourceData), S_OK);
 
-        Assert::AreEqual(resourceData.size, 15002u);
+        VERIFY_ARE_EQUAL(resourceData.size, 15002u);
 
         MrmFreeResource(resourceData.data);
         MrmDestroyResourceManager(resourceManager);
@@ -212,11 +215,11 @@ public:
     TEST_METHOD(ReadEmbeddedResource)
     {
         MrmManagerHandle resourceManager;
-        Assert::AreEqual(MrmCreateResourceManager(L".\\resources.pri", &resourceManager), S_OK);
+        VERIFY_ARE_EQUAL(MrmCreateResourceManager(L".\\resources.pri", &resourceManager), S_OK);
 
         MrmResourceData resourceData {};
-        Assert::AreEqual(MrmLoadEmbeddedResource(resourceManager, nullptr, nullptr, L"Files/Controls/AlbumBasicInfoControl.xbf", &resourceData), S_OK);
-        Assert::AreEqual(resourceData.size, 15002u);
+        VERIFY_ARE_EQUAL(MrmLoadEmbeddedResource(resourceManager, nullptr, nullptr, L"Files/Controls/AlbumBasicInfoControl.xbf", &resourceData), S_OK);
+        VERIFY_ARE_EQUAL(resourceData.size, 15002u);
 
         MrmFreeResource(resourceData.data);
         MrmDestroyResourceManager(resourceManager);
@@ -225,10 +228,10 @@ public:
     TEST_METHOD(ReadEmbeddedResourceAsString_Fails)
     {
         MrmManagerHandle resourceManager;
-        Assert::AreEqual(MrmCreateResourceManager(L".\\resources.pri", &resourceManager), S_OK);
+        VERIFY_ARE_EQUAL(MrmCreateResourceManager(L".\\resources.pri", &resourceManager), S_OK);
 
         wchar_t* resourceString;
-        Assert::AreEqual(MrmLoadStringResource(resourceManager, nullptr, nullptr, L"Files/Controls/AlbumBasicInfoControl.xbf", &resourceString), HRESULT_FROM_WIN32(ERROR_MRM_RESOURCE_TYPE_MISMATCH));
+        VERIFY_ARE_EQUAL(MrmLoadStringResource(resourceManager, nullptr, nullptr, L"Files/Controls/AlbumBasicInfoControl.xbf", &resourceString), HRESULT_FROM_WIN32(ERROR_MRM_RESOURCE_TYPE_MISMATCH));
 
         MrmDestroyResourceManager(resourceManager);
     }
@@ -236,19 +239,19 @@ public:
     TEST_METHOD(ReadStringOrEmbeddedResource)
     {
         MrmManagerHandle resourceManager;
-        Assert::AreEqual(MrmCreateResourceManager(L".\\resources.pri", &resourceManager), S_OK);
+        VERIFY_ARE_EQUAL(MrmCreateResourceManager(L".\\resources.pri", &resourceManager), S_OK);
 
         {
             MrmType resourceType;
             wchar_t* resourceString;
             MrmResourceData resourceData {};
 
-            Assert::AreEqual(MrmLoadStringOrEmbeddedResource(resourceManager, nullptr, nullptr, L"Files/Controls/AlbumBasicInfoControl.xbf", &resourceType, &resourceString, &resourceData), S_OK);
+            VERIFY_ARE_EQUAL(MrmLoadStringOrEmbeddedResource(resourceManager, nullptr, nullptr, L"Files/Controls/AlbumBasicInfoControl.xbf", &resourceType, &resourceString, &resourceData), S_OK);
 
-            Assert::IsNull(resourceString);
-            Assert::IsTrue(resourceType == MrmType_Embedded);
-            Assert::IsNotNull(resourceData.data);
-            Assert::AreEqual(resourceData.size, 15002u);
+            VERIFY_IS_NULL(resourceString);
+            VERIFY_IS_TRUE(resourceType == MrmType_Embedded);
+            VERIFY_IS_NOT_NULL(resourceData.data);
+            VERIFY_ARE_EQUAL(resourceData.size, 15002u);
 
             MrmFreeResource(resourceData.data);
         }
@@ -258,13 +261,13 @@ public:
             wchar_t* resourceString;
             MrmResourceData resourceData {};
 
-            Assert::AreEqual(MrmLoadStringOrEmbeddedResource(resourceManager, nullptr, nullptr, L"resources/IDS_MANIFEST_MUSIC_APP_NAME", &resourceType, &resourceString, &resourceData), S_OK);
+            VERIFY_ARE_EQUAL(MrmLoadStringOrEmbeddedResource(resourceManager, nullptr, nullptr, L"resources/IDS_MANIFEST_MUSIC_APP_NAME", &resourceType, &resourceString, &resourceData), S_OK);
 
-            Assert::IsNotNull(resourceString);
-            Assert::IsTrue(resourceType == MrmType_String);
-            Assert::IsNull(resourceData.data);
-            Assert::AreEqual(resourceData.size, 0u);
-            Assert::AreEqual(resourceString, L"Groove Music");
+            VERIFY_IS_NOT_NULL(resourceString);
+            VERIFY_IS_TRUE(resourceType == MrmType_String);
+            VERIFY_IS_NULL(resourceData.data);
+            VERIFY_ARE_EQUAL(resourceData.size, 0u);
+            VERIFY_ARE_EQUAL(resourceString, L"Groove Music");
 
             MrmFreeResource(resourceString);
         }
@@ -275,25 +278,25 @@ public:
     TEST_METHOD(ReadStringOrEmbeddedResourceWithQualifierOverride)
     {
         MrmManagerHandle resourceManager;
-        Assert::AreEqual(MrmCreateResourceManager(L".\\resources.pri", &resourceManager), S_OK);
+        VERIFY_ARE_EQUAL(MrmCreateResourceManager(L".\\resources.pri", &resourceManager), S_OK);
 
         MrmContextHandle resourceContext;
-        Assert::AreEqual(MrmCreateResourceContext(resourceManager, &resourceContext), S_OK);
+        VERIFY_ARE_EQUAL(MrmCreateResourceContext(resourceManager, &resourceContext), S_OK);
 
-        Assert::AreEqual(MrmSetQualifier(resourceContext, L"Contrast", L"WHITE"), S_OK);
-        Assert::AreEqual(MrmSetQualifier(resourceContext, L"TargetSize", L"96"), S_OK);
+        VERIFY_ARE_EQUAL(MrmSetQualifier(resourceContext, L"Contrast", L"WHITE"), S_OK);
+        VERIFY_ARE_EQUAL(MrmSetQualifier(resourceContext, L"TargetSize", L"96"), S_OK);
 
         {
             MrmType resourceType;
             wchar_t* resourceString;
             MrmResourceData resourceData {};
 
-            Assert::AreEqual(MrmLoadStringOrEmbeddedResource(resourceManager, resourceContext, nullptr, L"Files/Controls/AlbumBasicInfoControl.xbf", &resourceType, &resourceString, &resourceData), S_OK);
+            VERIFY_ARE_EQUAL(MrmLoadStringOrEmbeddedResource(resourceManager, resourceContext, nullptr, L"Files/Controls/AlbumBasicInfoControl.xbf", &resourceType, &resourceString, &resourceData), S_OK);
 
-            Assert::IsNull(resourceString);
-            Assert::IsTrue(resourceType == MrmType_Embedded);
-            Assert::IsNotNull(resourceData.data);
-            Assert::AreEqual(resourceData.size, 15002u);
+            VERIFY_IS_NULL(resourceString);
+            VERIFY_IS_TRUE(resourceType == MrmType_Embedded);
+            VERIFY_IS_NOT_NULL(resourceData.data);
+            VERIFY_ARE_EQUAL(resourceData.size, 15002u);
 
             MrmFreeResource(resourceData.data);
         }
@@ -303,30 +306,30 @@ public:
             wchar_t* resourceString;
             MrmResourceData resourceData {};
 
-            Assert::AreEqual(MrmLoadStringOrEmbeddedResource(resourceManager, resourceContext, nullptr, L"Files/Assets/AppList.png", &resourceType, &resourceString, &resourceData), S_OK);
+            VERIFY_ARE_EQUAL(MrmLoadStringOrEmbeddedResource(resourceManager, resourceContext, nullptr, L"Files/Assets/AppList.png", &resourceType, &resourceString, &resourceData), S_OK);
 
-            Assert::IsNotNull(resourceString);
-            Assert::IsTrue(resourceType == MrmType_Path);
-            Assert::IsNull(resourceData.data);
-            Assert::AreEqual(resourceData.size, 0u);
+            VERIFY_IS_NOT_NULL(resourceString);
+            VERIFY_IS_TRUE(resourceType == MrmType_Path);
+            VERIFY_IS_NULL(resourceData.data);
+            VERIFY_ARE_EQUAL(resourceData.size, 0u);
 
             // File resources have the path of the PRI file prepended to turn them into fully qualified paths.
-            Assert::IsNotNull(wcsstr(resourceString, L"Assets\\contrast-white\\AppList.targetsize-96_contrast-white.png"));
+            VERIFY_IS_NOT_NULL(wcsstr(resourceString, L"Assets\\contrast-white\\AppList.targetsize-96_contrast-white.png"));
 
             MrmFreeResource(resourceString);
 
             UINT32 qualifierCount;
             PWSTR* qualifierNames = nullptr;
             PWSTR* qualifierValues = nullptr;
-            Assert::AreEqual(MrmLoadStringOrEmbeddedResourceWithQualifierValues(resourceManager, resourceContext, nullptr, L"Files/Assets/AppList.png", &resourceType, &resourceString, &resourceData, &qualifierCount, &qualifierNames, &qualifierValues), S_OK);
+            VERIFY_ARE_EQUAL(MrmLoadStringOrEmbeddedResourceWithQualifierValues(resourceManager, resourceContext, nullptr, L"Files/Assets/AppList.png", &resourceType, &resourceString, &resourceData, &qualifierCount, &qualifierNames, &qualifierValues), S_OK);
 
-            Assert::IsNotNull(resourceString);
-            Assert::IsTrue(resourceType == MrmType_Path);
-            Assert::IsNull(resourceData.data);
-            Assert::AreEqual(resourceData.size, 0u);
+            VERIFY_IS_NOT_NULL(resourceString);
+            VERIFY_IS_TRUE(resourceType == MrmType_Path);
+            VERIFY_IS_NULL(resourceData.data);
+            VERIFY_ARE_EQUAL(resourceData.size, 0u);
 
             // File resources have the path of the PRI file prepended to turn them into fully qualified paths.
-            Assert::IsNotNull(wcsstr(resourceString, L"Assets\\contrast-white\\AppList.targetsize-96_contrast-white.png"));
+            VERIFY_IS_NOT_NULL(wcsstr(resourceString, L"Assets\\contrast-white\\AppList.targetsize-96_contrast-white.png"));
 
             VerifyQualifierValue(qualifierCount, qualifierNames, qualifierValues, L"Contrast", L"WHITE");
             VerifyQualifierValue(qualifierCount, qualifierNames, qualifierValues, L"TargetSize", L"96");
@@ -343,18 +346,18 @@ public:
     TEST_METHOD(EnumerateResourceMap)
     {
         MrmManagerHandle resourceManager;
-        Assert::AreEqual(MrmCreateResourceManager(L".\\resources.pri", &resourceManager), S_OK);
+        VERIFY_ARE_EQUAL(MrmCreateResourceManager(L".\\resources.pri", &resourceManager), S_OK);
 
         // Enumerate under Microsoft.UI.Xaml/Resources
         MrmMapHandle childResourceMap;
-        Assert::AreEqual(MrmGetChildResourceMap(resourceManager, nullptr, L"Microsoft.UI.Xaml", &childResourceMap), S_OK);
+        VERIFY_ARE_EQUAL(MrmGetChildResourceMap(resourceManager, nullptr, L"Microsoft.UI.Xaml", &childResourceMap), S_OK);
 
         MrmMapHandle childChildResourceMap;
-        Assert::AreEqual(MrmGetChildResourceMap(resourceManager, childResourceMap, L"Resources", &childChildResourceMap), S_OK);
+        VERIFY_ARE_EQUAL(MrmGetChildResourceMap(resourceManager, childResourceMap, L"Resources", &childChildResourceMap), S_OK);
 
         UINT32 count;
-        Assert::AreEqual(MrmGetResourceCount(resourceManager, childChildResourceMap, &count), S_OK);
-        Assert::AreEqual<UINT32>(count, 78);
+        VERIFY_ARE_EQUAL(MrmGetResourceCount(resourceManager, childChildResourceMap, &count), S_OK);
+        VERIFY_ARE_EQUAL(count, static_cast<UINT32>(78));
 
         MrmType resourceType;
         wchar_t* resourceString = nullptr;
@@ -362,39 +365,39 @@ public:
         MrmResourceData resourceData {};
         for (UINT32 i = 0; i < count; i++)
         {
-            Assert::AreEqual(MrmLoadStringOrEmbeddedResourceByIndex(resourceManager, nullptr, childChildResourceMap, i, &resourceType, &resourceName, &resourceString, &resourceData), S_OK);
+            VERIFY_ARE_EQUAL(MrmLoadStringOrEmbeddedResourceByIndex(resourceManager, nullptr, childChildResourceMap, i, &resourceType, &resourceName, &resourceString, &resourceData), S_OK);
 
-            Assert::IsTrue(resourceType == MrmType_String);
-            Assert::IsNull(resourceData.data);
-            Assert::AreEqual(resourceData.size, 0u);
+            VERIFY_IS_TRUE(resourceType == MrmType_String);
+            VERIFY_IS_NULL(resourceData.data);
+            VERIFY_ARE_EQUAL(resourceData.size, 0u);
 
             switch (i)
             {
             case 0:
             {
-                Assert::AreEqual(resourceName, L"AutomationNameAlphaSlider");
-                Assert::AreEqual(resourceString, L"Opacity");
+                VERIFY_ARE_EQUAL(resourceName, L"AutomationNameAlphaSlider");
+                VERIFY_ARE_EQUAL(resourceString, L"Opacity");
                 break;
             }
 
             case 1:
             {
-                Assert::AreEqual(resourceName, L"AutomationNameAlphaTextBox");
-                Assert::AreEqual(resourceString, L"Opacity");
+                VERIFY_ARE_EQUAL(resourceName, L"AutomationNameAlphaTextBox");
+                VERIFY_ARE_EQUAL(resourceString, L"Opacity");
                 break;
             }
 
             case 2:
             {
-                Assert::AreEqual(resourceName, L"AutomationNameBlueTextBox");
-                Assert::AreEqual(resourceString, L"Blue");
+                VERIFY_ARE_EQUAL(resourceName, L"AutomationNameBlueTextBox");
+                VERIFY_ARE_EQUAL(resourceString, L"Blue");
                 break;
             }
 
             case 77:
             {
-                Assert::AreEqual(resourceName, L"ValueStringValueSliderWithoutColorName");
-                Assert::AreEqual(resourceString, L"%1!u!");
+                VERIFY_ARE_EQUAL(resourceName, L"ValueStringValueSliderWithoutColorName");
+                VERIFY_ARE_EQUAL(resourceString, L"%1!u!");
                 break;
             }
             }
@@ -405,46 +408,46 @@ public:
             resourceName = nullptr;
         }
 
-        Assert::AreEqual(MrmLoadStringOrEmbeddedResourceByIndex(resourceManager, nullptr, childChildResourceMap, count, &resourceType, &resourceName, &resourceString, &resourceData), HRESULT_FROM_WIN32(ERROR_RANGE_NOT_FOUND));
+        VERIFY_ARE_EQUAL(MrmLoadStringOrEmbeddedResourceByIndex(resourceManager, nullptr, childChildResourceMap, count, &resourceType, &resourceName, &resourceString, &resourceData), HRESULT_FROM_WIN32(ERROR_RANGE_NOT_FOUND));
 
         // Enumerate under Files/Controls
-        Assert::AreEqual(MrmGetChildResourceMap(resourceManager, nullptr, L"Files", &childResourceMap), S_OK);
-        Assert::AreEqual(MrmGetChildResourceMap(resourceManager, childResourceMap, L"Controls", &childChildResourceMap), S_OK);
-        Assert::AreEqual(MrmGetResourceCount(resourceManager, childChildResourceMap, &count), S_OK);
-        Assert::AreEqual<UINT32>(count, 28);
+        VERIFY_ARE_EQUAL(MrmGetChildResourceMap(resourceManager, nullptr, L"Files", &childResourceMap), S_OK);
+        VERIFY_ARE_EQUAL(MrmGetChildResourceMap(resourceManager, childResourceMap, L"Controls", &childChildResourceMap), S_OK);
+        VERIFY_ARE_EQUAL(MrmGetResourceCount(resourceManager, childChildResourceMap, &count), S_OK);
+        VERIFY_ARE_EQUAL(count, static_cast<UINT32>(28));
 
         for (UINT32 i = 0; i < count; i++)
         {
-            Assert::AreEqual(MrmLoadStringOrEmbeddedResourceByIndex(resourceManager, nullptr, childChildResourceMap, i, &resourceType, &resourceName, &resourceString, &resourceData), S_OK);
+            VERIFY_ARE_EQUAL(MrmLoadStringOrEmbeddedResourceByIndex(resourceManager, nullptr, childChildResourceMap, i, &resourceType, &resourceName, &resourceString, &resourceData), S_OK);
 
-            Assert::IsTrue(resourceType == MrmType_Embedded);
-            Assert::IsNull(resourceString);
-            Assert::IsNotNull(resourceData.data);
-            Assert::IsTrue(resourceData.size != 0);
+            VERIFY_IS_TRUE(resourceType == MrmType_Embedded);
+            VERIFY_IS_NULL(resourceString);
+            VERIFY_IS_NOT_NULL(resourceData.data);
+            VERIFY_IS_TRUE(resourceData.size != 0);
 
             switch (i)
             {
             case 0:
             {
-                Assert::AreEqual(resourceName, L"AlbumBasicInfoControl.xbf");
+                VERIFY_ARE_EQUAL(resourceName, L"AlbumBasicInfoControl.xbf");
                 break;
             }
 
             case 1:
             {
-                Assert::AreEqual(resourceName, L"AlbumMetadataEditDialog.xbf");
+                VERIFY_ARE_EQUAL(resourceName, L"AlbumMetadataEditDialog.xbf");
                 break;
             }
 
             case 2:
             {
-                Assert::AreEqual(resourceName, L"ArtistBasicInfoControl.xbf");
+                VERIFY_ARE_EQUAL(resourceName, L"ArtistBasicInfoControl.xbf");
                 break;
             }
 
             case 27:
             {
-                Assert::AreEqual(resourceName, L"TrackMetadataEditDialog.xbf");
+                VERIFY_ARE_EQUAL(resourceName, L"TrackMetadataEditDialog.xbf");
                 break;
             }
             }
@@ -456,7 +459,7 @@ public:
             resourceData.size = 0;
         }
 
-        Assert::AreEqual(MrmLoadStringOrEmbeddedResourceByIndex(resourceManager, nullptr, childChildResourceMap, count, &resourceType, &resourceName, &resourceString, &resourceData), HRESULT_FROM_WIN32(ERROR_RANGE_NOT_FOUND));
+        VERIFY_ARE_EQUAL(MrmLoadStringOrEmbeddedResourceByIndex(resourceManager, nullptr, childChildResourceMap, count, &resourceType, &resourceName, &resourceString, &resourceData), HRESULT_FROM_WIN32(ERROR_RANGE_NOT_FOUND));
 
         MrmDestroyResourceManager(resourceManager);
     }
@@ -464,10 +467,10 @@ public:
     TEST_METHOD(ReadResourceStringWithQualifierValue)
     {
         MrmManagerHandle resourceManager;
-        Assert::AreEqual(MrmCreateResourceManager(L".\\resources.pri", &resourceManager), S_OK);
+        VERIFY_ARE_EQUAL(MrmCreateResourceManager(L".\\resources.pri", &resourceManager), S_OK);
 
         MrmContextHandle resourceContext;
-        Assert::AreEqual(MrmCreateResourceContext(resourceManager, &resourceContext), S_OK);
+        VERIFY_ARE_EQUAL(MrmCreateResourceContext(resourceManager, &resourceContext), S_OK);
 
         MrmType resourceType;
         wchar_t* resourceString;
@@ -475,20 +478,20 @@ public:
         UINT32 qualifierCount;
         PWSTR* qualifierNames = nullptr;
         PWSTR* qualifierValues = nullptr;
-        Assert::AreEqual(MrmSetQualifier(resourceContext, L"Language", L"en-US"), S_OK);
-        Assert::AreEqual(MrmLoadStringOrEmbeddedResourceWithQualifierValues(resourceManager, resourceContext, nullptr, L"resources/IDS_WHATS_NEW_1710_2_EQUALIZER_TITLE", &resourceType, &resourceString, &resourceData, &qualifierCount, &qualifierNames, &qualifierValues), S_OK);
+        VERIFY_ARE_EQUAL(MrmSetQualifier(resourceContext, L"Language", L"en-US"), S_OK);
+        VERIFY_ARE_EQUAL(MrmLoadStringOrEmbeddedResourceWithQualifierValues(resourceManager, resourceContext, nullptr, L"resources/IDS_WHATS_NEW_1710_2_EQUALIZER_TITLE", &resourceType, &resourceString, &resourceData, &qualifierCount, &qualifierNames, &qualifierValues), S_OK);
 
-        Assert::AreEqual(resourceString, L"Equalizer");
+        VERIFY_ARE_EQUAL(resourceString, L"Equalizer");
         MrmFreeResource(resourceString);
 
         VerifyQualifierValue(qualifierCount, qualifierNames, qualifierValues, L"Language", L"en-US");
         MrmFreeQualifierNamesOrValues(qualifierCount, qualifierNames);
         MrmFreeQualifierNamesOrValues(qualifierCount, qualifierValues);
 
-        Assert::AreEqual(MrmSetQualifier(resourceContext, L"Language", L"en-GB"), S_OK);
-        Assert::AreEqual(MrmLoadStringOrEmbeddedResourceWithQualifierValues(resourceManager, resourceContext, nullptr, L"resources/IDS_WHATS_NEW_1710_2_EQUALIZER_TITLE", &resourceType, &resourceString, &resourceData, &qualifierCount, &qualifierNames, &qualifierValues), S_OK);
+        VERIFY_ARE_EQUAL(MrmSetQualifier(resourceContext, L"Language", L"en-GB"), S_OK);
+        VERIFY_ARE_EQUAL(MrmLoadStringOrEmbeddedResourceWithQualifierValues(resourceManager, resourceContext, nullptr, L"resources/IDS_WHATS_NEW_1710_2_EQUALIZER_TITLE", &resourceType, &resourceString, &resourceData, &qualifierCount, &qualifierNames, &qualifierValues), S_OK);
 
-        Assert::AreEqual(resourceString, L"Equaliser");
+        VERIFY_ARE_EQUAL(resourceString, L"Equaliser");
         MrmFreeResource(resourceString);
 
         VerifyQualifierValue(qualifierCount, qualifierNames, qualifierValues, L"Language", L"en-GB");
@@ -496,10 +499,10 @@ public:
         MrmFreeQualifierNamesOrValues(qualifierCount, qualifierValues);
 
         // en-AU is closer to en-GB
-        Assert::AreEqual(MrmSetQualifier(resourceContext, L"Language", L"en-AU"), S_OK);
-        Assert::AreEqual(MrmLoadStringOrEmbeddedResourceWithQualifierValues(resourceManager, resourceContext, nullptr, L"resources/IDS_WHATS_NEW_1710_2_EQUALIZER_TITLE", &resourceType, &resourceString, &resourceData, &qualifierCount, &qualifierNames, &qualifierValues), S_OK);
+        VERIFY_ARE_EQUAL(MrmSetQualifier(resourceContext, L"Language", L"en-AU"), S_OK);
+        VERIFY_ARE_EQUAL(MrmLoadStringOrEmbeddedResourceWithQualifierValues(resourceManager, resourceContext, nullptr, L"resources/IDS_WHATS_NEW_1710_2_EQUALIZER_TITLE", &resourceType, &resourceString, &resourceData, &qualifierCount, &qualifierNames, &qualifierValues), S_OK);
 
-        Assert::AreEqual(resourceString, L"Equaliser");
+        VERIFY_ARE_EQUAL(resourceString, L"Equaliser");
         MrmFreeResource(resourceString);
 
         // resource candidate for en-GB is picked as en-AU is closer to en-GB
@@ -513,16 +516,16 @@ public:
     TEST_METHOD(InvalidPriName)
     {
         MrmManagerHandle resourceManager;
-        Assert::AreEqual(MrmCreateResourceManager(L"invalid.pri", &resourceManager), HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND));
+        VERIFY_ARE_EQUAL(MrmCreateResourceManager(L"invalid.pri", &resourceManager), HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND));
     }
 
     TEST_METHOD(InvalidResource)
     {
         MrmManagerHandle resourceManager;
-        Assert::AreEqual(MrmCreateResourceManager(L".\\resources.pri", &resourceManager), S_OK);
+        VERIFY_ARE_EQUAL(MrmCreateResourceManager(L".\\resources.pri", &resourceManager), S_OK);
 
         wchar_t* resourceString;
-        Assert::AreEqual(MrmLoadStringResource(resourceManager, nullptr, nullptr, L"resources/wrongresource", &resourceString), HRESULT_FROM_WIN32(ERROR_MRM_NAMED_RESOURCE_NOT_FOUND));
+        VERIFY_ARE_EQUAL(MrmLoadStringResource(resourceManager, nullptr, nullptr, L"resources/wrongresource", &resourceString), HRESULT_FROM_WIN32(ERROR_MRM_NAMED_RESOURCE_NOT_FOUND));
 
         MrmDestroyResourceManager(resourceManager);
     }
@@ -530,13 +533,13 @@ public:
     TEST_METHOD(RepeatedCalls)
     {
         MrmManagerHandle resourceManager;
-        Assert::AreEqual(MrmCreateResourceManager(L".\\resources.pri", &resourceManager), S_OK);
+        VERIFY_ARE_EQUAL(MrmCreateResourceManager(L".\\resources.pri", &resourceManager), S_OK);
 
         for (unsigned int i = 0; i < 100; i++)
         {
             wchar_t* resourceString;
-            Assert::AreEqual(MrmLoadStringResource(resourceManager, nullptr, nullptr, L"resources/IDS_MANIFEST_MUSIC_APP_NAME", &resourceString), S_OK);
-            Assert::AreEqual(resourceString, L"Groove Music");
+            VERIFY_ARE_EQUAL(MrmLoadStringResource(resourceManager, nullptr, nullptr, L"resources/IDS_MANIFEST_MUSIC_APP_NAME", &resourceString), S_OK);
+            VERIFY_ARE_EQUAL(resourceString, L"Groove Music");
 
             MrmFreeResource(resourceString);
         }
@@ -549,11 +552,11 @@ public:
         for (unsigned int i = 0; i < 100; i++)
         {
             MrmManagerHandle resourceManager;
-            Assert::AreEqual(MrmCreateResourceManager(L".\\resources.pri", &resourceManager), S_OK);
+            VERIFY_ARE_EQUAL(MrmCreateResourceManager(L".\\resources.pri", &resourceManager), S_OK);
 
             wchar_t* resourceString;
-            Assert::AreEqual(MrmLoadStringResource(resourceManager, nullptr, nullptr, L"resources/IDS_MANIFEST_MUSIC_APP_NAME", &resourceString), S_OK);
-            Assert::AreEqual(resourceString, L"Groove Music");
+            VERIFY_ARE_EQUAL(MrmLoadStringResource(resourceManager, nullptr, nullptr, L"resources/IDS_MANIFEST_MUSIC_APP_NAME", &resourceString), S_OK);
+            VERIFY_ARE_EQUAL(resourceString, L"Groove Music");
 
             MrmFreeResource(resourceString);
             MrmDestroyResourceManager(resourceManager);
@@ -563,35 +566,35 @@ public:
     TEST_METHOD(GetFilePath)
     {
         wchar_t* path;
-        Assert::AreEqual(MrmGetFilePathFromName(L"resources.pri", &path), S_OK);
-        Assert::IsNotNull(wcsstr(path, L"resources.pri"));
+        VERIFY_ARE_EQUAL(MrmGetFilePathFromName(L"resources.pri", &path), S_OK);
+        VERIFY_IS_NOT_NULL(wcsstr(path, L"resources.pri"));
         MrmFreeResource(path);
 
-        Assert::AreEqual(MrmGetFilePathFromName(L"something.pri", &path), S_OK);
+        VERIFY_ARE_EQUAL(MrmGetFilePathFromName(L"something.pri", &path), S_OK);
         // Even if the file doesn't exist, we will still return a path. This is for those don't use PRI for resource.
-        Assert::IsNotNull(wcsstr(path, L"something.pri"));
+        VERIFY_IS_NOT_NULL(wcsstr(path, L"something.pri"));
         MrmFreeResource(path);
 
-        Assert::AreEqual(MrmGetFilePathFromName(nullptr, &path), S_OK);
-        Assert::IsNotNull(wcsstr(path, L"resources.pri"));
+        VERIFY_ARE_EQUAL(MrmGetFilePathFromName(nullptr, &path), S_OK);
+        VERIFY_IS_NOT_NULL(wcsstr(path, L"resources.pri"));
         MrmFreeResource(path);
     }
 
 private:
     void VerifyQualifierValue(UINT32 qualifierCount, PWSTR* qualifierNames, PWSTR* qualifierValues, PCWSTR name, PCWSTR expectedValue)
     {
-        Assert::IsTrue(qualifierCount > 0);
+        VERIFY_IS_TRUE(qualifierCount > 0);
         bool found = false;
         for (UINT32 i = 0; i < qualifierCount; i++)
         {
             if (0 == _wcsicmp(name, qualifierNames[i]))
             {
-                Assert::IsTrue(0 == _wcsicmp(expectedValue, qualifierValues[i]));
+                VERIFY_IS_TRUE(0 == _wcsicmp(expectedValue, qualifierValues[i]));
                 found = true;
                 break;
             }
         }
-        Assert::IsTrue(found);
+        VERIFY_IS_TRUE(found);
     }
 };
 } // namespace UnitTest

--- a/dev/MRTCore/mrt/Core/unittests/MrmTests.cpp
+++ b/dev/MRTCore/mrt/Core/unittests/MrmTests.cpp
@@ -18,10 +18,6 @@ public:
 
     TEST_METHOD(ReadResourceString)
     {
-        wchar_t path[MAX_PATH] = {};
-        VERIFY_WIN32_BOOL_SUCCEEDED(GetCurrentDirectory(ARRAYSIZE(path), path));
-        WEX::Logging::Log::Comment(WEX::Common::String().Format(L"Current directory: %s", path));
-
         MrmManagerHandle resourceManager;
         VERIFY_ARE_EQUAL(MrmCreateResourceManager(L".\\resources.pri", &resourceManager), S_OK);
 

--- a/dev/MRTCore/mrt/Core/unittests/MrmTests.cpp
+++ b/dev/MRTCore/mrt/Core/unittests/MrmTests.cpp
@@ -9,6 +9,18 @@ using namespace WEX::Common;
 using namespace WEX::TestExecution;
 using namespace WEX::Logging;
 
+inline void VerifyStringEqual(PCWSTR szExpected, PCWSTR szActual, PCWSTR message = L"")
+{
+    VERIFY_ARE_EQUAL(0, wcscmp(szExpected, szActual),
+        WEX::Common::String().Format(L"Expected: %s Actual: %s %s", szExpected, szActual, message));
+}
+
+inline void VerifyStringEqualIgnoreCase(PCWSTR szExpected, PCWSTR szActual, PCWSTR message = L"")
+{
+    VERIFY_ARE_EQUAL(CSTR_EQUAL, CompareStringOrdinal(szExpected, -1, szActual, -1, /*ignoreCase*/ TRUE),
+        WEX::Common::String().Format(L"Expected: %s Actual: %s %s", szExpected, szActual, message));
+}
+
 namespace UnitTest
 {
 class BasicTest
@@ -48,7 +60,7 @@ public:
         wchar_t* resourceString;
         VERIFY_ARE_EQUAL(MrmLoadStringResource(resourceManager, nullptr, nullptr, L"resources/IDS_MANIFEST_MUSIC_APP_NAME", &resourceString), S_OK);
 
-        VERIFY_ARE_EQUAL(wcscmp(resourceString, L"Groove Music"), 0);
+        VerifyStringEqual(resourceString, L"Groove Music");
 
         MrmFreeResource(resourceString);
         MrmDestroyResourceManager(resourceManager);
@@ -68,7 +80,7 @@ public:
         wchar_t* resourceString;
         VERIFY_ARE_EQUAL(MrmLoadStringResource(resourceManager, nullptr, childChildResourceMap, L"HelpTextMoreButton", &resourceString), S_OK);
 
-        VERIFY_ARE_EQUAL(wcscmp(resourceString, L"Invoke to show or hide the text entry fields."), 0);
+        VerifyStringEqual(resourceString, L"Invoke to show or hide the text entry fields.");
 
         MrmFreeResource(resourceString);
         MrmDestroyResourceManager(resourceManager);
@@ -82,7 +94,7 @@ public:
         wchar_t* resourceString;
         VERIFY_ARE_EQUAL(MrmLoadStringResourceFromResourceUri(resourceManager, nullptr, L"ms-resource://Microsoft.ZuneMusic/resources/IDS_MANIFEST_MUSIC_APP_NAME", &resourceString), S_OK);
 
-        VERIFY_ARE_EQUAL(wcscmp(resourceString, L"Groove Music"), 0);
+        VerifyStringEqual(resourceString, L"Groove Music");
 
         MrmFreeResource(resourceString);
         MrmDestroyResourceManager(resourceManager);
@@ -96,7 +108,7 @@ public:
         wchar_t* resourceString;
         VERIFY_ARE_EQUAL(MrmLoadStringResourceFromResourceUri(resourceManager, nullptr, L"ms-resource:///resources/IDS_MANIFEST_MUSIC_APP_NAME", &resourceString), S_OK);
 
-        VERIFY_ARE_EQUAL(wcscmp(resourceString, L"Groove Music"), 0);
+        VerifyStringEqual(resourceString, L"Groove Music");
 
         MrmFreeResource(resourceString);
         MrmDestroyResourceManager(resourceManager);
@@ -147,8 +159,8 @@ public:
 
         // We currently support 12 qualifiers defined in MrmConstants.h
         VERIFY_ARE_EQUAL(size, 12u);
-        VERIFY_ARE_EQUAL(wcscmp(*qualifierNames, L"Language"), 0);
-        VERIFY_ARE_EQUAL(wcscmp(*(qualifierNames + 11), L"Custom"), 0);
+        VerifyStringEqual(*qualifierNames, L"Language");
+        VerifyStringEqual(*(qualifierNames + 11), L"Custom");
 
         MrmFreeQualifierNamesOrValues(size, qualifierNames);
 
@@ -164,11 +176,11 @@ public:
 
             wchar_t* qualifierValue;
             VERIFY_ARE_EQUAL(MrmGetQualifier(resourceContext, L"Contrast", &qualifierValue), S_OK);
-            VERIFY_ARE_EQUAL(wcscmp(qualifierValue, L"WHITE"), 0);
+            VerifyStringEqual(qualifierValue, L"WHITE");
             MrmFreeResource(qualifierValue);
 
             VERIFY_ARE_EQUAL(MrmGetQualifier(resourceContext, L"TargetSize", &qualifierValue), S_OK);
-            VERIFY_ARE_EQUAL(wcscmp(qualifierValue, L"96"), 0);
+            VerifyStringEqual(qualifierValue, L"96");
             MrmFreeResource(qualifierValue);
 
             MrmFreeResource(resourceString);
@@ -203,20 +215,20 @@ public:
         VERIFY_ARE_EQUAL(MrmSetQualifier(resourceContext, L"Language", L"en-US"), S_OK);
         VERIFY_ARE_EQUAL(MrmLoadStringResource(resourceManager, resourceContext, nullptr, L"resources/IDS_WHATS_NEW_1710_2_EQUALIZER_TITLE", &resourceString), S_OK);
 
-        VERIFY_ARE_EQUAL(wcscmp(resourceString, L"Equalizer"), 0);
+        VerifyStringEqual(resourceString, L"Equalizer");
         MrmFreeResource(resourceString);
 
         VERIFY_ARE_EQUAL(MrmSetQualifier(resourceContext, L"Language", L"en-GB"), S_OK);
         VERIFY_ARE_EQUAL(MrmLoadStringResource(resourceManager, resourceContext, nullptr, L"resources/IDS_WHATS_NEW_1710_2_EQUALIZER_TITLE", &resourceString), S_OK);
 
-        VERIFY_ARE_EQUAL(wcscmp(resourceString, L"Equaliser"), 0);
+        VerifyStringEqual(resourceString, L"Equaliser");
         MrmFreeResource(resourceString);
 
         // en-AU is closer to en-GB
         VERIFY_ARE_EQUAL(MrmSetQualifier(resourceContext, L"Language", L"en-AU"), S_OK);
         VERIFY_ARE_EQUAL(MrmLoadStringResource(resourceManager, resourceContext, nullptr, L"resources/IDS_WHATS_NEW_1710_2_EQUALIZER_TITLE", &resourceString), S_OK);
 
-        VERIFY_ARE_EQUAL(wcscmp(resourceString, L"Equaliser"), 0);
+        VerifyStringEqual(resourceString, L"Equaliser");
         MrmFreeResource(resourceString);
 
         MrmDestroyResourceManager(resourceManager);
@@ -291,7 +303,7 @@ public:
             VERIFY_IS_TRUE(resourceType == MrmType_String);
             VERIFY_IS_NULL(resourceData.data);
             VERIFY_ARE_EQUAL(resourceData.size, 0u);
-            VERIFY_ARE_EQUAL(wcscmp(resourceString, L"Groove Music"), 0);
+            VerifyStringEqual(resourceString, L"Groove Music");
 
             MrmFreeResource(resourceString);
         }
@@ -381,7 +393,7 @@ public:
 
         UINT32 count;
         VERIFY_ARE_EQUAL(MrmGetResourceCount(resourceManager, childChildResourceMap, &count), S_OK);
-        VERIFY_ARE_EQUAL(count, static_cast<UINT32>(78));
+        VERIFY_ARE_EQUAL(count, 78u);
 
         MrmType resourceType;
         wchar_t* resourceString = nullptr;
@@ -399,29 +411,29 @@ public:
             {
             case 0:
             {
-                VERIFY_ARE_EQUAL(wcscmp(resourceName, L"AutomationNameAlphaSlider"), 0);
-                VERIFY_ARE_EQUAL(wcscmp(resourceString, L"Opacity"), 0);
+                VerifyStringEqual(resourceName, L"AutomationNameAlphaSlider");
+                VerifyStringEqual(resourceString, L"Opacity");
                 break;
             }
 
             case 1:
             {
-                VERIFY_ARE_EQUAL(wcscmp(resourceName, L"AutomationNameAlphaTextBox"), 0);
-                VERIFY_ARE_EQUAL(wcscmp(resourceString, L"Opacity"), 0);
+                VerifyStringEqual(resourceName, L"AutomationNameAlphaTextBox");
+                VerifyStringEqual(resourceString, L"Opacity");
                 break;
             }
 
             case 2:
             {
-                VERIFY_ARE_EQUAL(wcscmp(resourceName, L"AutomationNameBlueTextBox"), 0);
-                VERIFY_ARE_EQUAL(wcscmp(resourceString, L"Blue"), 0);
+                VerifyStringEqual(resourceName, L"AutomationNameBlueTextBox");
+                VerifyStringEqual(resourceString, L"Blue");
                 break;
             }
 
             case 77:
             {
-                VERIFY_ARE_EQUAL(wcscmp(resourceName, L"ValueStringValueSliderWithoutColorName"), 0);
-                VERIFY_ARE_EQUAL(wcscmp(resourceString, L"%1!u!"), 0);
+                VerifyStringEqual(resourceName, L"ValueStringValueSliderWithoutColorName");
+                VerifyStringEqual(resourceString, L"%1!u!");
                 break;
             }
             }
@@ -438,7 +450,7 @@ public:
         VERIFY_ARE_EQUAL(MrmGetChildResourceMap(resourceManager, nullptr, L"Files", &childResourceMap), S_OK);
         VERIFY_ARE_EQUAL(MrmGetChildResourceMap(resourceManager, childResourceMap, L"Controls", &childChildResourceMap), S_OK);
         VERIFY_ARE_EQUAL(MrmGetResourceCount(resourceManager, childChildResourceMap, &count), S_OK);
-        VERIFY_ARE_EQUAL(count, static_cast<UINT32>(28));
+        VERIFY_ARE_EQUAL(count, 28u);
 
         for (UINT32 i = 0; i < count; i++)
         {
@@ -453,25 +465,25 @@ public:
             {
             case 0:
             {
-                VERIFY_ARE_EQUAL(wcscmp(resourceName, L"AlbumBasicInfoControl.xbf"), 0);
+                VerifyStringEqual(resourceName, L"AlbumBasicInfoControl.xbf");
                 break;
             }
 
             case 1:
             {
-                VERIFY_ARE_EQUAL(wcscmp(resourceName, L"AlbumMetadataEditDialog.xbf"), 0);
+                VerifyStringEqual(resourceName, L"AlbumMetadataEditDialog.xbf");
                 break;
             }
 
             case 2:
             {
-                VERIFY_ARE_EQUAL(wcscmp(resourceName, L"ArtistBasicInfoControl.xbf"), 0);
+                VerifyStringEqual(resourceName, L"ArtistBasicInfoControl.xbf");
                 break;
             }
 
             case 27:
             {
-                VERIFY_ARE_EQUAL(wcscmp(resourceName, L"TrackMetadataEditDialog.xbf"), 0);
+                VerifyStringEqual(resourceName, L"TrackMetadataEditDialog.xbf");
                 break;
             }
             }
@@ -505,7 +517,7 @@ public:
         VERIFY_ARE_EQUAL(MrmSetQualifier(resourceContext, L"Language", L"en-US"), S_OK);
         VERIFY_ARE_EQUAL(MrmLoadStringOrEmbeddedResourceWithQualifierValues(resourceManager, resourceContext, nullptr, L"resources/IDS_WHATS_NEW_1710_2_EQUALIZER_TITLE", &resourceType, &resourceString, &resourceData, &qualifierCount, &qualifierNames, &qualifierValues), S_OK);
 
-        VERIFY_ARE_EQUAL(wcscmp(resourceString, L"Equalizer"), 0);
+        VerifyStringEqual(resourceString, L"Equalizer");
         MrmFreeResource(resourceString);
 
         VerifyQualifierValue(qualifierCount, qualifierNames, qualifierValues, L"Language", L"en-US");
@@ -515,7 +527,7 @@ public:
         VERIFY_ARE_EQUAL(MrmSetQualifier(resourceContext, L"Language", L"en-GB"), S_OK);
         VERIFY_ARE_EQUAL(MrmLoadStringOrEmbeddedResourceWithQualifierValues(resourceManager, resourceContext, nullptr, L"resources/IDS_WHATS_NEW_1710_2_EQUALIZER_TITLE", &resourceType, &resourceString, &resourceData, &qualifierCount, &qualifierNames, &qualifierValues), S_OK);
 
-        VERIFY_ARE_EQUAL(wcscmp(resourceString, L"Equaliser"), 0);
+        VerifyStringEqual(resourceString, L"Equaliser");
         MrmFreeResource(resourceString);
 
         VerifyQualifierValue(qualifierCount, qualifierNames, qualifierValues, L"Language", L"en-GB");
@@ -526,7 +538,7 @@ public:
         VERIFY_ARE_EQUAL(MrmSetQualifier(resourceContext, L"Language", L"en-AU"), S_OK);
         VERIFY_ARE_EQUAL(MrmLoadStringOrEmbeddedResourceWithQualifierValues(resourceManager, resourceContext, nullptr, L"resources/IDS_WHATS_NEW_1710_2_EQUALIZER_TITLE", &resourceType, &resourceString, &resourceData, &qualifierCount, &qualifierNames, &qualifierValues), S_OK);
 
-        VERIFY_ARE_EQUAL(wcscmp(resourceString, L"Equaliser"), 0);
+        VerifyStringEqual(resourceString, L"Equaliser");
         MrmFreeResource(resourceString);
 
         // resource candidate for en-GB is picked as en-AU is closer to en-GB
@@ -563,7 +575,7 @@ public:
         {
             wchar_t* resourceString;
             VERIFY_ARE_EQUAL(MrmLoadStringResource(resourceManager, nullptr, nullptr, L"resources/IDS_MANIFEST_MUSIC_APP_NAME", &resourceString), S_OK);
-            VERIFY_ARE_EQUAL(wcscmp(resourceString, L"Groove Music"), 0);
+            VerifyStringEqual(resourceString, L"Groove Music");
 
             MrmFreeResource(resourceString);
         }
@@ -580,7 +592,7 @@ public:
 
             wchar_t* resourceString;
             VERIFY_ARE_EQUAL(MrmLoadStringResource(resourceManager, nullptr, nullptr, L"resources/IDS_MANIFEST_MUSIC_APP_NAME", &resourceString), S_OK);
-            VERIFY_ARE_EQUAL(wcscmp(resourceString, L"Groove Music"), 0);
+            VerifyStringEqual(resourceString, L"Groove Music");
 
             MrmFreeResource(resourceString);
             MrmDestroyResourceManager(resourceManager);
@@ -607,13 +619,13 @@ public:
 private:
     void VerifyQualifierValue(UINT32 qualifierCount, PWSTR* qualifierNames, PWSTR* qualifierValues, PCWSTR name, PCWSTR expectedValue)
     {
-        VERIFY_IS_TRUE(qualifierCount > 0);
+        VERIFY_IS_GREATER_THAN(qualifierCount, 0u);
         bool found = false;
         for (UINT32 i = 0; i < qualifierCount; i++)
         {
             if (0 == _wcsicmp(name, qualifierNames[i]))
             {
-                VERIFY_IS_TRUE(0 == _wcsicmp(expectedValue, qualifierValues[i]));
+                VerifyStringEqualIgnoreCase(expectedValue, qualifierValues[i]);
                 found = true;
                 break;
             }

--- a/dev/MRTCore/mrt/Core/unittests/MrmTests.cpp
+++ b/dev/MRTCore/mrt/Core/unittests/MrmTests.cpp
@@ -24,7 +24,7 @@ public:
         wchar_t* resourceString;
         VERIFY_ARE_EQUAL(MrmLoadStringResource(resourceManager, nullptr, nullptr, L"resources/IDS_MANIFEST_MUSIC_APP_NAME", &resourceString), S_OK);
 
-        VERIFY_ARE_EQUAL(resourceString, L"Groove Music");
+        VERIFY_ARE_EQUAL(wcscmp(resourceString, L"Groove Music"), 0);
 
         MrmFreeResource(resourceString);
         MrmDestroyResourceManager(resourceManager);
@@ -44,7 +44,7 @@ public:
         wchar_t* resourceString;
         VERIFY_ARE_EQUAL(MrmLoadStringResource(resourceManager, nullptr, childChildResourceMap, L"HelpTextMoreButton", &resourceString), S_OK);
 
-        VERIFY_ARE_EQUAL(resourceString, L"Invoke to show or hide the text entry fields.");
+        VERIFY_ARE_EQUAL(wcscmp(resourceString, L"Invoke to show or hide the text entry fields."), 0);
 
         MrmFreeResource(resourceString);
         MrmDestroyResourceManager(resourceManager);
@@ -58,7 +58,7 @@ public:
         wchar_t* resourceString;
         VERIFY_ARE_EQUAL(MrmLoadStringResourceFromResourceUri(resourceManager, nullptr, L"ms-resource://Microsoft.ZuneMusic/resources/IDS_MANIFEST_MUSIC_APP_NAME", &resourceString), S_OK);
 
-        VERIFY_ARE_EQUAL(resourceString, L"Groove Music");
+        VERIFY_ARE_EQUAL(wcscmp(resourceString, L"Groove Music"), 0);
 
         MrmFreeResource(resourceString);
         MrmDestroyResourceManager(resourceManager);
@@ -72,7 +72,7 @@ public:
         wchar_t* resourceString;
         VERIFY_ARE_EQUAL(MrmLoadStringResourceFromResourceUri(resourceManager, nullptr, L"ms-resource:///resources/IDS_MANIFEST_MUSIC_APP_NAME", &resourceString), S_OK);
 
-        VERIFY_ARE_EQUAL(resourceString, L"Groove Music");
+        VERIFY_ARE_EQUAL(wcscmp(resourceString, L"Groove Music"), 0);
 
         MrmFreeResource(resourceString);
         MrmDestroyResourceManager(resourceManager);
@@ -123,8 +123,8 @@ public:
 
         // We currently support 12 qualifiers defined in MrmConstants.h
         VERIFY_ARE_EQUAL(size, 12u);
-        VERIFY_ARE_EQUAL(*qualifierNames, L"Language");
-        VERIFY_ARE_EQUAL(*(qualifierNames + 11), L"Custom");
+        VERIFY_ARE_EQUAL(wcscmp(*qualifierNames, L"Language"), 0);
+        VERIFY_ARE_EQUAL(wcscmp(*(qualifierNames + 11), L"Custom"), 0);
 
         MrmFreeQualifierNamesOrValues(size, qualifierNames);
 
@@ -140,11 +140,11 @@ public:
 
             wchar_t* qualifierValue;
             VERIFY_ARE_EQUAL(MrmGetQualifier(resourceContext, L"Contrast", &qualifierValue), S_OK);
-            VERIFY_ARE_EQUAL(qualifierValue, L"WHITE");
+            VERIFY_ARE_EQUAL(wcscmp(qualifierValue, L"WHITE"), 0);
             MrmFreeResource(qualifierValue);
 
             VERIFY_ARE_EQUAL(MrmGetQualifier(resourceContext, L"TargetSize", &qualifierValue), S_OK);
-            VERIFY_ARE_EQUAL(qualifierValue, L"96");
+            VERIFY_ARE_EQUAL(wcscmp(qualifierValue, L"96"), 0);
             MrmFreeResource(qualifierValue);
 
             MrmFreeResource(resourceString);
@@ -179,20 +179,20 @@ public:
         VERIFY_ARE_EQUAL(MrmSetQualifier(resourceContext, L"Language", L"en-US"), S_OK);
         VERIFY_ARE_EQUAL(MrmLoadStringResource(resourceManager, resourceContext, nullptr, L"resources/IDS_WHATS_NEW_1710_2_EQUALIZER_TITLE", &resourceString), S_OK);
 
-        VERIFY_ARE_EQUAL(resourceString, L"Equalizer");
+        VERIFY_ARE_EQUAL(wcscmp(resourceString, L"Equalizer"), 0);
         MrmFreeResource(resourceString);
 
         VERIFY_ARE_EQUAL(MrmSetQualifier(resourceContext, L"Language", L"en-GB"), S_OK);
         VERIFY_ARE_EQUAL(MrmLoadStringResource(resourceManager, resourceContext, nullptr, L"resources/IDS_WHATS_NEW_1710_2_EQUALIZER_TITLE", &resourceString), S_OK);
 
-        VERIFY_ARE_EQUAL(resourceString, L"Equaliser");
+        VERIFY_ARE_EQUAL(wcscmp(resourceString, L"Equaliser"), 0);
         MrmFreeResource(resourceString);
 
         // en-AU is closer to en-GB
         VERIFY_ARE_EQUAL(MrmSetQualifier(resourceContext, L"Language", L"en-AU"), S_OK);
         VERIFY_ARE_EQUAL(MrmLoadStringResource(resourceManager, resourceContext, nullptr, L"resources/IDS_WHATS_NEW_1710_2_EQUALIZER_TITLE", &resourceString), S_OK);
 
-        VERIFY_ARE_EQUAL(resourceString, L"Equaliser");
+        VERIFY_ARE_EQUAL(wcscmp(resourceString, L"Equaliser"), 0);
         MrmFreeResource(resourceString);
 
         MrmDestroyResourceManager(resourceManager);
@@ -267,7 +267,7 @@ public:
             VERIFY_IS_TRUE(resourceType == MrmType_String);
             VERIFY_IS_NULL(resourceData.data);
             VERIFY_ARE_EQUAL(resourceData.size, 0u);
-            VERIFY_ARE_EQUAL(resourceString, L"Groove Music");
+            VERIFY_ARE_EQUAL(wcscmp(resourceString, L"Groove Music"), 0);
 
             MrmFreeResource(resourceString);
         }
@@ -375,29 +375,29 @@ public:
             {
             case 0:
             {
-                VERIFY_ARE_EQUAL(resourceName, L"AutomationNameAlphaSlider");
-                VERIFY_ARE_EQUAL(resourceString, L"Opacity");
+                VERIFY_ARE_EQUAL(wcscmp(resourceName, L"AutomationNameAlphaSlider"), 0);
+                VERIFY_ARE_EQUAL(wcscmp(resourceString, L"Opacity"), 0);
                 break;
             }
 
             case 1:
             {
-                VERIFY_ARE_EQUAL(resourceName, L"AutomationNameAlphaTextBox");
-                VERIFY_ARE_EQUAL(resourceString, L"Opacity");
+                VERIFY_ARE_EQUAL(wcscmp(resourceName, L"AutomationNameAlphaTextBox"), 0);
+                VERIFY_ARE_EQUAL(wcscmp(resourceString, L"Opacity"), 0);
                 break;
             }
 
             case 2:
             {
-                VERIFY_ARE_EQUAL(resourceName, L"AutomationNameBlueTextBox");
-                VERIFY_ARE_EQUAL(resourceString, L"Blue");
+                VERIFY_ARE_EQUAL(wcscmp(resourceName, L"AutomationNameBlueTextBox"), 0);
+                VERIFY_ARE_EQUAL(wcscmp(resourceString, L"Blue"), 0);
                 break;
             }
 
             case 77:
             {
-                VERIFY_ARE_EQUAL(resourceName, L"ValueStringValueSliderWithoutColorName");
-                VERIFY_ARE_EQUAL(resourceString, L"%1!u!");
+                VERIFY_ARE_EQUAL(wcscmp(resourceName, L"ValueStringValueSliderWithoutColorName"), 0);
+                VERIFY_ARE_EQUAL(wcscmp(resourceString, L"%1!u!"), 0);
                 break;
             }
             }
@@ -429,25 +429,25 @@ public:
             {
             case 0:
             {
-                VERIFY_ARE_EQUAL(resourceName, L"AlbumBasicInfoControl.xbf");
+                VERIFY_ARE_EQUAL(wcscmp(resourceName, L"AlbumBasicInfoControl.xbf"), 0);
                 break;
             }
 
             case 1:
             {
-                VERIFY_ARE_EQUAL(resourceName, L"AlbumMetadataEditDialog.xbf");
+                VERIFY_ARE_EQUAL(wcscmp(resourceName, L"AlbumMetadataEditDialog.xbf"), 0);
                 break;
             }
 
             case 2:
             {
-                VERIFY_ARE_EQUAL(resourceName, L"ArtistBasicInfoControl.xbf");
+                VERIFY_ARE_EQUAL(wcscmp(resourceName, L"ArtistBasicInfoControl.xbf"), 0);
                 break;
             }
 
             case 27:
             {
-                VERIFY_ARE_EQUAL(resourceName, L"TrackMetadataEditDialog.xbf");
+                VERIFY_ARE_EQUAL(wcscmp(resourceName, L"TrackMetadataEditDialog.xbf"), 0);
                 break;
             }
             }
@@ -481,7 +481,7 @@ public:
         VERIFY_ARE_EQUAL(MrmSetQualifier(resourceContext, L"Language", L"en-US"), S_OK);
         VERIFY_ARE_EQUAL(MrmLoadStringOrEmbeddedResourceWithQualifierValues(resourceManager, resourceContext, nullptr, L"resources/IDS_WHATS_NEW_1710_2_EQUALIZER_TITLE", &resourceType, &resourceString, &resourceData, &qualifierCount, &qualifierNames, &qualifierValues), S_OK);
 
-        VERIFY_ARE_EQUAL(resourceString, L"Equalizer");
+        VERIFY_ARE_EQUAL(wcscmp(resourceString, L"Equalizer"), 0);
         MrmFreeResource(resourceString);
 
         VerifyQualifierValue(qualifierCount, qualifierNames, qualifierValues, L"Language", L"en-US");
@@ -491,7 +491,7 @@ public:
         VERIFY_ARE_EQUAL(MrmSetQualifier(resourceContext, L"Language", L"en-GB"), S_OK);
         VERIFY_ARE_EQUAL(MrmLoadStringOrEmbeddedResourceWithQualifierValues(resourceManager, resourceContext, nullptr, L"resources/IDS_WHATS_NEW_1710_2_EQUALIZER_TITLE", &resourceType, &resourceString, &resourceData, &qualifierCount, &qualifierNames, &qualifierValues), S_OK);
 
-        VERIFY_ARE_EQUAL(resourceString, L"Equaliser");
+        VERIFY_ARE_EQUAL(wcscmp(resourceString, L"Equaliser"), 0);
         MrmFreeResource(resourceString);
 
         VerifyQualifierValue(qualifierCount, qualifierNames, qualifierValues, L"Language", L"en-GB");
@@ -502,7 +502,7 @@ public:
         VERIFY_ARE_EQUAL(MrmSetQualifier(resourceContext, L"Language", L"en-AU"), S_OK);
         VERIFY_ARE_EQUAL(MrmLoadStringOrEmbeddedResourceWithQualifierValues(resourceManager, resourceContext, nullptr, L"resources/IDS_WHATS_NEW_1710_2_EQUALIZER_TITLE", &resourceType, &resourceString, &resourceData, &qualifierCount, &qualifierNames, &qualifierValues), S_OK);
 
-        VERIFY_ARE_EQUAL(resourceString, L"Equaliser");
+        VERIFY_ARE_EQUAL(wcscmp(resourceString, L"Equaliser"), 0);
         MrmFreeResource(resourceString);
 
         // resource candidate for en-GB is picked as en-AU is closer to en-GB
@@ -539,7 +539,7 @@ public:
         {
             wchar_t* resourceString;
             VERIFY_ARE_EQUAL(MrmLoadStringResource(resourceManager, nullptr, nullptr, L"resources/IDS_MANIFEST_MUSIC_APP_NAME", &resourceString), S_OK);
-            VERIFY_ARE_EQUAL(resourceString, L"Groove Music");
+            VERIFY_ARE_EQUAL(wcscmp(resourceString, L"Groove Music"), 0);
 
             MrmFreeResource(resourceString);
         }
@@ -556,7 +556,7 @@ public:
 
             wchar_t* resourceString;
             VERIFY_ARE_EQUAL(MrmLoadStringResource(resourceManager, nullptr, nullptr, L"resources/IDS_MANIFEST_MUSIC_APP_NAME", &resourceString), S_OK);
-            VERIFY_ARE_EQUAL(resourceString, L"Groove Music");
+            VERIFY_ARE_EQUAL(wcscmp(resourceString, L"Groove Music"), 0);
 
             MrmFreeResource(resourceString);
             MrmDestroyResourceManager(resourceManager);

--- a/dev/MRTCore/mrt/Core/unittests/UnitTest.vcxproj
+++ b/dev/MRTCore/mrt/Core/unittests/UnitTest.vcxproj
@@ -41,6 +41,7 @@
     <RootNamespace>UnitTest</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectSubType>NativeUnitTestProject</ProjectSubType>
+    <ProjectName>UnitTest</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -346,7 +347,17 @@
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </CopyFileToFolders>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <ImportGroup Label="ExtensionTargets">
+    <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\..\packages\Microsoft.Taef.10.58.210222006-develop\build\Microsoft.Taef.targets" Condition="Exists('..\..\packages\Microsoft.Taef.10.58.210222006-develop\build\Microsoft.Taef.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\Microsoft.Taef.10.58.210222006-develop\build\Microsoft.Taef.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Taef.10.58.210222006-develop\build\Microsoft.Taef.targets'))" />
+  </Target>
 </Project>

--- a/dev/MRTCore/mrt/Core/unittests/packages.config
+++ b/dev/MRTCore/mrt/Core/unittests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Taef" version="10.58.210222006-develop" targetFramework="native" />
+</packages>


### PR DESCRIPTION
This PR converts the MRT Core Unit Tests from the MSTest framework to TAEF.
This will enable running the Unit Tests inside Helix in the future in another PR.

There are 4 different test suites for MRT Core currently:
- BaseUnitTests 
  - Already using TAEF.
  - This already runs in Helix but the test results aren't reported in ADO.
- UnitTests
  - This PR converts this test from MSTest to TAEF, and runs this test on the build machine.
- ManagedTests
  - Uses MSTest/vstest.console.exe to run.
  - Will investigate converting this to TAEF in a future PR.
- UnpackagedTests
  - Already using TAEF.
  - Doesn't yet run in the CI pipeline. (I plan to try and enable this in a future PR).

#### Notes on the changes:
I had to use `wcscmp` for comparing strings in the tests, as otherwise the `VERIFY_` macro would get confused and try to compare the value of the pointer instead of the string itself. Another possible option that I tried was to wrap each pointer with `std::wstring` (which is what some other tests in the repo do). However, it seemed a bit wasteful to construct a temporary string if we can just call `wcscmp`.

~~We can't invoke the converted TAEF UnitTest via the `VSTest` Azure DevOps Task in the pipeline, and need to invoke `te.exe` directly. The UnitTest expects to be invoked from the same directory as the test binaries, such that `resources.pri` is alongside the `UnitTest.dll` file. If it is invoked from another directory, then the tests will fail.~~
~~This means that we can't invoke the test using the ADO VSTest task (which would use the TAEF VS Test adapter) as that would have a different current directory. Unfortunately, there is no way (from what I can tell) to change the current working directory with the VSTest task.~~
~~The VSTest task *always* uses this as  the current working directory: `$(System.DefaultWorkingDirectory)`
I looked into the code for `VSTest@2`, and it always sets the working directory before executing:
https://github.com/microsoft/azure-pipelines-tasks/blob/master/Tasks/VsTestV2/vstest.ts#L221
Sadly there is no option to change this.
There is also no way to use a custom "runsettings" file to change the working directory either.~~

While working on this, I noticed that the WinUI/MUX Helix conversion scripts that are used for converting the TAEF WTL output to xUnit don't seem to actually be working. Note that if the test fails then the build pipeline will still fail, so we aren't losing any test coverage. However, this does mean that we lack the nice/pretty reporting features that the ADO UI provides. (But you can still see the test output in the pipeline results). The converted xUnit files seem okay on the surface, so I'll need to investigate more as to why this isn't working.
