### PR TITLE
Update Bootstrap dll to match PRfwk

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,7 +28,7 @@
     <!-- If not set, default it to no . -->
     <ProjectReunionBuildPipeline>0</ProjectReunionBuildPipeline>
   </PropertyGroup>
-  <Target Name="DirectoryBuildPropsInfo">
+  <Target Name="DirectoryBuildPropsInfo" Condition="$(ProjectReunionBuildPipeline) == '1'">
     <Message Importance="High" Text="Directory.Build.props detects ProjectReunionBuildPipeline=$(ProjectReunionBuildPipeline)"/>
   </Target>
 


### PR DESCRIPTION
MddBootstrapInitialize() had a PRfwk package name mismatch (looking for "Microsoft.ProjectReunion.Framework" instead of "Microsoft.ProjectReunion.<major>.<minor>[-tag]"). Corrected to look for the right PRfwk package name (now and into the future with different MajorMinor and/or Tag). As a happy perk tests are also unaffected.

Verified tests pass AND the Reunion nuget pass as expected with this fix to Microsoft.ProjectReunion.dll!

Also changed Directory.Build.props to not produce unnecessary noise during inner-loop builds.