### PR TITLE
DynamicDependencies: Change WinRT namespace to Microsoft.Windows.ApplicationModel.DynamicDependency

### DIFF
--- a/build/AzurePipelinesTemplates/ProjectReunion-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/ProjectReunion-CreateNugetPackage-Job.yml
@@ -60,7 +60,7 @@ jobs:
         Copy-Item -Path "$targetsFilePath\AppxManifest.xml" -Destination "$fullpackagePath\AppxManifest.xml"
 
         Copy-Item -Path "$targetsFilePath\Intellisense\Microsoft.Windows.AppLifecycle.xml" -Destination "$fullpackagePath\lib\uap10.0\Microsoft.Windows.AppLifecycle.xml"
-        Copy-Item -Path "$targetsFilePath\Intellisense\Microsoft.ApplicationModel.DynamicDependency.xml" -Destination "$fullpackagePath\lib\uap10.0\Microsoft.ApplicationModel.DynamicDependency.xml"
+        Copy-Item -Path "$targetsFilePath\Intellisense\Microsoft.Windows.ApplicationModel.DynamicDependency.xml" -Destination "$fullpackagePath\lib\uap10.0\Microsoft.Windows.ApplicationModel.DynamicDependency.xml"
 
   # - script: |
   #     dir /s $(Build.SourcesDirectory)

--- a/build/CopyFilesToStagingDir.ps1
+++ b/build/CopyFilesToStagingDir.ps1
@@ -38,7 +38,7 @@ PublishFile $OverrideDir\DynamicDependency-Override.json $FullPublishDir\
 PublishFile $FullBuildOutput\ProjectReunion_DLL\Microsoft.ProjectReunion.dll $FullPublishDir\Microsoft.ProjectReunion\
 PublishFile $FullBuildOutput\ProjectReunion_DLL\Microsoft.ProjectReunion.lib $FullPublishDir\Microsoft.ProjectReunion\
 PublishFile $FullBuildOutput\ProjectReunion_DLL\Microsoft.Windows.AppLifecycle.winmd $FullPublishDir\Microsoft.ProjectReunion\
-PublishFile $FullBuildOutput\ProjectReunion_DLL\Microsoft.ApplicationModel.DynamicDependency.winmd $FullPublishDir\Microsoft.ProjectReunion\
+PublishFile $FullBuildOutput\ProjectReunion_DLL\Microsoft.Windows.ApplicationModel.DynamicDependency.winmd $FullPublishDir\Microsoft.ProjectReunion\
 PublishFile $FullBuildOutput\ProjectReunion_DLL\MsixDynamicDependency.h $FullPublishDir\Microsoft.ProjectReunion\
 PublishFile $FullBuildOutput\ProjectReunion_DLL\wil_msixdynamicdependency.h $FullPublishDir\Microsoft.ProjectReunion\
 #
@@ -119,7 +119,7 @@ PublishFile $FullBuildOutput\ProjectReunion_DLL\Microsoft.Windows.AppLifecycle.w
 PublishFile $FullBuildOutput\ProjectReunion_BootstrapDLL\Microsoft.ProjectReunion.Bootstrap.dll $NugetDir\runtimes\lib\native\$Platform
 PublishFile $FullBuildOutput\ProjectReunion_BootstrapDLL\Microsoft.ProjectReunion.Bootstrap.pdb $NugetDir\runtimes\lib\native\$Platform
 PublishFile $FullBuildOutput\ProjectReunion_DLL\Microsoft.Windows.AppLifecycle.winmd $NugetDir\lib\native
-PublishFile $FullBuildOutput\ProjectReunion_DLL\Microsoft.ApplicationModel.DynamicDependency.winmd $NugetDir\lib\native
+PublishFile $FullBuildOutput\ProjectReunion_DLL\Microsoft.Windows.ApplicationModel.DynamicDependency.winmd $NugetDir\lib\native
 #
 # C#/WinRT Projections
 #

--- a/build/NuSpecs/AppxManifest.xml
+++ b/build/NuSpecs/AppxManifest.xml
@@ -28,11 +28,11 @@
       <InProcessServer>
         <Path>Microsoft.ProjectReunion.dll</Path>
           <!-- Dynamic Dependency -->
-          <ActivatableClass ActivatableClassId="Microsoft.ApplicationModel.DynamicDependency.AddPackageDependencyOptions" ThreadingModel="both" />
-          <ActivatableClass ActivatableClassId="Microsoft.ApplicationModel.DynamicDependency.CreatePackageDependencyOptions" ThreadingModel="both" />
-          <ActivatableClass ActivatableClassId="Microsoft.ApplicationModel.DynamicDependency.PackageDependency" ThreadingModel="both" />
-          <ActivatableClass ActivatableClassId="Microsoft.ApplicationModel.DynamicDependency.PackageDependencyContext" ThreadingModel="both" />
-          <ActivatableClass ActivatableClassId="Microsoft.ApplicationModel.DynamicDependency.PackageDependencyRank" ThreadingModel="both" />
+          <ActivatableClass ActivatableClassId="Microsoft.Windows.ApplicationModel.DynamicDependency.AddPackageDependencyOptions" ThreadingModel="both" />
+          <ActivatableClass ActivatableClassId="Microsoft.Windows.ApplicationModel.DynamicDependency.CreatePackageDependencyOptions" ThreadingModel="both" />
+          <ActivatableClass ActivatableClassId="Microsoft.Windows.ApplicationModel.DynamicDependency.PackageDependency" ThreadingModel="both" />
+          <ActivatableClass ActivatableClassId="Microsoft.Windows.ApplicationModel.DynamicDependency.PackageDependencyContext" ThreadingModel="both" />
+          <ActivatableClass ActivatableClassId="Microsoft.Windows.ApplicationModel.DynamicDependency.PackageDependencyRank" ThreadingModel="both" />
 
           <!-- AppLifecycle -->
           <ActivatableClass ActivatableClassId="Microsoft.Windows.AppLifecycle.ActivationRegistrationManager" ThreadingModel="both" />

--- a/build/NuSpecs/Intellisense/Microsoft.Windows.ApplicationModel.DynamicDependency.xml
+++ b/build/NuSpecs/Intellisense/Microsoft.Windows.ApplicationModel.DynamicDependency.xml
@@ -2,7 +2,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <doc>
   <assembly>
-    <name>Microsoft.ApplicationModel.DynamicDependency</name>
+    <name>Microsoft.Windows.ApplicationModel.DynamicDependency</name>
   </assembly>
   <members>
   </members>

--- a/build/NuSpecs/ProjectReunion-Nuget-Native.WinRt.props
+++ b/build/NuSpecs/ProjectReunion-Nuget-Native.WinRt.props
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(AppxPackage)' != 'true'">
-    <Reference Include="Microsoft.ApplicationModel.DynamicDependency.winmd">
-      <HintPath>$(MSBuildThisFileDirectory)..\..\lib\native\Microsoft.ApplicationModel.DynamicDependency.winmd</HintPath>
+    <Reference Include="Microsoft.Windows.ApplicationModel.DynamicDependency.winmd">
+      <HintPath>$(MSBuildThisFileDirectory)..\..\lib\native\Microsoft.Windows.ApplicationModel.DynamicDependency.winmd</HintPath>
       <Implementation Condition="'$(ProjectReunionFrameworkPackage)' != 'true'">$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(_ProjectReunionFoundationPlatform)\native\Microsoft.ProjectReunion.dll</Implementation>
       <IsWinMDFile>true</IsWinMDFile>
     </Reference>

--- a/build/NuSpecs/ProjectReunion-Nuget-Native.targets
+++ b/build/NuSpecs/ProjectReunion-Nuget-Native.targets
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(AppxPackage)' != 'true'">
-    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\native\Microsoft.ApplicationModel.DynamicDependency.winmd">
+    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\native\Microsoft.Windows.ApplicationModel.DynamicDependency.winmd">
       <Private>false</Private>
       <Implementation>Microsoft.ProjectReunion.dll</Implementation>
     </Reference>

--- a/dev/DynamicDependency/M.AM.Converters.h
+++ b/dev/DynamicDependency/M.AM.Converters.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-namespace Microsoft::ApplicationModel::DynamicDependency
+namespace Microsoft::Windows::ApplicationModel::DynamicDependency
 {
     inline winrt::Windows::ApplicationModel::PackageVersion ToVersion(PACKAGE_VERSION const& from)
     {
@@ -25,27 +25,27 @@ namespace Microsoft::ApplicationModel::DynamicDependency
         return to;
     }
 
-    inline MddPackageDependencyProcessorArchitectures ToArchitectures(winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures const& architectures)
+    inline MddPackageDependencyProcessorArchitectures ToArchitectures(winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures const& architectures)
     {
-        static_assert(static_cast<int32_t>(winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures::None) == static_cast<int32_t>(MddPackageDependencyProcessorArchitectures::None), "WinRT/MddPackageDependencyProcessorArchitectures::None mismatch");
-        static_assert(static_cast<int32_t>(winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures::Neutral) == static_cast<int32_t>(MddPackageDependencyProcessorArchitectures::Neutral), "WinRT/MddPackageDependencyProcessorArchitectures::Neutral mismatch");
-        static_assert(static_cast<int32_t>(winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures::X86) == static_cast<int32_t>(MddPackageDependencyProcessorArchitectures::X86), "WinRT/MddPackageDependencyProcessorArchitectures::X86 mismatch");
-        static_assert(static_cast<int32_t>(winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures::X64) == static_cast<int32_t>(MddPackageDependencyProcessorArchitectures::X64), "WinRT/MddPackageDependencyProcessorArchitectures::X64 mismatch");
-        static_assert(static_cast<int32_t>(winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures::Arm) == static_cast<int32_t>(MddPackageDependencyProcessorArchitectures::Arm), "WinRT/MddPackageDependencyProcessorArchitectures::Arm mismatch");
-        static_assert(static_cast<int32_t>(winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures::Arm64) == static_cast<int32_t>(MddPackageDependencyProcessorArchitectures::Arm64), "WinRT/MddPackageDependencyProcessorArchitectures::Arm64 mismatch");
-        static_assert(static_cast<int32_t>(winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures::X86OnArm64) == static_cast<int32_t>(MddPackageDependencyProcessorArchitectures::X86OnArm64), "WinRT/MddPackageDependencyProcessorArchitectures::X86OnArm64 mismatch");
+        static_assert(static_cast<int32_t>(winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures::None) == static_cast<int32_t>(MddPackageDependencyProcessorArchitectures::None), "WinRT/MddPackageDependencyProcessorArchitectures::None mismatch");
+        static_assert(static_cast<int32_t>(winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures::Neutral) == static_cast<int32_t>(MddPackageDependencyProcessorArchitectures::Neutral), "WinRT/MddPackageDependencyProcessorArchitectures::Neutral mismatch");
+        static_assert(static_cast<int32_t>(winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures::X86) == static_cast<int32_t>(MddPackageDependencyProcessorArchitectures::X86), "WinRT/MddPackageDependencyProcessorArchitectures::X86 mismatch");
+        static_assert(static_cast<int32_t>(winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures::X64) == static_cast<int32_t>(MddPackageDependencyProcessorArchitectures::X64), "WinRT/MddPackageDependencyProcessorArchitectures::X64 mismatch");
+        static_assert(static_cast<int32_t>(winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures::Arm) == static_cast<int32_t>(MddPackageDependencyProcessorArchitectures::Arm), "WinRT/MddPackageDependencyProcessorArchitectures::Arm mismatch");
+        static_assert(static_cast<int32_t>(winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures::Arm64) == static_cast<int32_t>(MddPackageDependencyProcessorArchitectures::Arm64), "WinRT/MddPackageDependencyProcessorArchitectures::Arm64 mismatch");
+        static_assert(static_cast<int32_t>(winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures::X86OnArm64) == static_cast<int32_t>(MddPackageDependencyProcessorArchitectures::X86OnArm64), "WinRT/MddPackageDependencyProcessorArchitectures::X86OnArm64 mismatch");
         return static_cast<MddPackageDependencyProcessorArchitectures>(architectures);
     }
 
-    inline MddPackageDependencyLifetimeKind ToLifetimeKind(winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind const& lifetimeArtifactKind)
+    inline MddPackageDependencyLifetimeKind ToLifetimeKind(winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind const& lifetimeArtifactKind)
     {
-        static_assert(static_cast<int32_t>(winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind::Process) == static_cast<int32_t>(MddPackageDependencyLifetimeKind::Process), "WinRT/MddPackageDependencyLifetimeKind::Process mismatch");
-        static_assert(static_cast<int32_t>(winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind::FilePath) == static_cast<int32_t>(MddPackageDependencyLifetimeKind::FilePath), "WinRT/MddPackageDependencyLifetimeKind::FilePath mismatch");
-        static_assert(static_cast<int32_t>(winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind::RegistryKey) == static_cast<int32_t>(MddPackageDependencyLifetimeKind::RegistryKey), "WinRT/MddPackageDependencyLifetimeKind::ReistryKey mismatch");
+        static_assert(static_cast<int32_t>(winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind::Process) == static_cast<int32_t>(MddPackageDependencyLifetimeKind::Process), "WinRT/MddPackageDependencyLifetimeKind::Process mismatch");
+        static_assert(static_cast<int32_t>(winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind::FilePath) == static_cast<int32_t>(MddPackageDependencyLifetimeKind::FilePath), "WinRT/MddPackageDependencyLifetimeKind::FilePath mismatch");
+        static_assert(static_cast<int32_t>(winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind::RegistryKey) == static_cast<int32_t>(MddPackageDependencyLifetimeKind::RegistryKey), "WinRT/MddPackageDependencyLifetimeKind::ReistryKey mismatch");
         return static_cast<MddPackageDependencyLifetimeKind>(lifetimeArtifactKind);
     }
 
-    inline MddCreatePackageDependencyOptions ToCreateOptions(winrt::Microsoft::ApplicationModel::DynamicDependency::CreatePackageDependencyOptions const& options, MddCreatePackageDependencyOptions const& defaultValue = MddCreatePackageDependencyOptions::None)
+    inline MddCreatePackageDependencyOptions ToCreateOptions(winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::CreatePackageDependencyOptions const& options, MddCreatePackageDependencyOptions const& defaultValue = MddCreatePackageDependencyOptions::None)
     {
         auto mddOptions{ defaultValue };
         if (!options.VerifyDependencyResolution())
@@ -55,7 +55,7 @@ namespace Microsoft::ApplicationModel::DynamicDependency
         return mddOptions;
     }
 
-    inline MddAddPackageDependencyOptions ToAddOptions(winrt::Microsoft::ApplicationModel::DynamicDependency::AddPackageDependencyOptions const& options)
+    inline MddAddPackageDependencyOptions ToAddOptions(winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::AddPackageDependencyOptions const& options)
     {
         auto mddOptions{ MddAddPackageDependencyOptions::None };
         if (options.PrependIfRankCollision())
@@ -65,12 +65,12 @@ namespace Microsoft::ApplicationModel::DynamicDependency
         return mddOptions;
     }
 
-    inline winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyContextId ToContextId(MDD_PACKAGEDEPENDENCY_CONTEXT context)
+    inline winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyContextId ToContextId(MDD_PACKAGEDEPENDENCY_CONTEXT context)
     {
-        return winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyContextId{ static_cast<uint64_t>(reinterpret_cast<INT_PTR>(context)) };
+        return winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyContextId{ static_cast<uint64_t>(reinterpret_cast<INT_PTR>(context)) };
     }
 
-    inline MDD_PACKAGEDEPENDENCY_CONTEXT ToContext(winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyContextId contextId)
+    inline MDD_PACKAGEDEPENDENCY_CONTEXT ToContext(winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyContextId contextId)
     {
         return reinterpret_cast<MDD_PACKAGEDEPENDENCY_CONTEXT>(static_cast<INT_PTR>(contextId.Id));
     }

--- a/dev/DynamicDependency/M.AM.DD.AddPackageDependencyOptions.cpp
+++ b/dev/DynamicDependency/M.AM.DD.AddPackageDependencyOptions.cpp
@@ -4,9 +4,9 @@
 #include "pch.h"
 
 #include "M.AM.DD.AddPackageDependencyOptions.h"
-#include "Microsoft.ApplicationModel.DynamicDependency.AddPackageDependencyOptions.g.cpp"
+#include "Microsoft.Windows.ApplicationModel.DynamicDependency.AddPackageDependencyOptions.g.cpp"
 
-namespace winrt::Microsoft::ApplicationModel::DynamicDependency::implementation
+namespace winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::implementation
 {
     int32_t AddPackageDependencyOptions::Rank()
     {

--- a/dev/DynamicDependency/M.AM.DD.AddPackageDependencyOptions.h
+++ b/dev/DynamicDependency/M.AM.DD.AddPackageDependencyOptions.h
@@ -3,11 +3,11 @@
 
 #pragma once
 
-#include "Microsoft.ApplicationModel.DynamicDependency.AddPackageDependencyOptions.g.h"
+#include "Microsoft.Windows.ApplicationModel.DynamicDependency.AddPackageDependencyOptions.g.h"
 
 #include <MsixDynamicDependency.h>
 
-namespace winrt::Microsoft::ApplicationModel::DynamicDependency::implementation
+namespace winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::implementation
 {
     struct AddPackageDependencyOptions : AddPackageDependencyOptionsT<AddPackageDependencyOptions>
     {
@@ -23,7 +23,7 @@ namespace winrt::Microsoft::ApplicationModel::DynamicDependency::implementation
         bool m_prependIfRankCollision{};
     };
 }
-namespace winrt::Microsoft::ApplicationModel::DynamicDependency::factory_implementation
+namespace winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::factory_implementation
 {
     struct AddPackageDependencyOptions : AddPackageDependencyOptionsT<AddPackageDependencyOptions, implementation::AddPackageDependencyOptions>
     {

--- a/dev/DynamicDependency/M.AM.DD.CreatePackageDependencyOptions.cpp
+++ b/dev/DynamicDependency/M.AM.DD.CreatePackageDependencyOptions.cpp
@@ -4,15 +4,15 @@
 #include "pch.h"
 
 #include "M.AM.DD.CreatePackageDependencyOptions.h"
-#include "Microsoft.ApplicationModel.DynamicDependency.CreatePackageDependencyOptions.g.cpp"
+#include "Microsoft.Windows.ApplicationModel.DynamicDependency.CreatePackageDependencyOptions.g.cpp"
 
-namespace winrt::Microsoft::ApplicationModel::DynamicDependency::implementation
+namespace winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::implementation
 {
     winrt::PackageDependencyProcessorArchitectures CreatePackageDependencyOptions::Architectures()
     {
         return m_architectures;
     }
-    void CreatePackageDependencyOptions::Architectures(Microsoft::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures const& value)
+    void CreatePackageDependencyOptions::Architectures(Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures const& value)
     {
         m_architectures = value;
     }
@@ -32,7 +32,7 @@ namespace winrt::Microsoft::ApplicationModel::DynamicDependency::implementation
         return m_lifetimeArtifactKind;
     }
 
-    void CreatePackageDependencyOptions::LifetimeArtifactKind(Microsoft::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind const& value)
+    void CreatePackageDependencyOptions::LifetimeArtifactKind(Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind const& value)
     {
         m_lifetimeArtifactKind = value;
     }

--- a/dev/DynamicDependency/M.AM.DD.CreatePackageDependencyOptions.h
+++ b/dev/DynamicDependency/M.AM.DD.CreatePackageDependencyOptions.h
@@ -3,22 +3,22 @@
 
 #pragma once
 
-#include "Microsoft.ApplicationModel.DynamicDependency.CreatePackageDependencyOptions.g.h"
+#include "Microsoft.Windows.ApplicationModel.DynamicDependency.CreatePackageDependencyOptions.g.h"
 
 #include "winrt_namespaces.h"
 
-namespace winrt::Microsoft::ApplicationModel::DynamicDependency::implementation
+namespace winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::implementation
 {
     struct CreatePackageDependencyOptions : CreatePackageDependencyOptionsT<CreatePackageDependencyOptions>
     {
         CreatePackageDependencyOptions() = default;
 
         winrt::PackageDependencyProcessorArchitectures Architectures();
-        void Architectures(Microsoft::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures const& value);
+        void Architectures(Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures const& value);
         bool VerifyDependencyResolution();
         void VerifyDependencyResolution(bool value);
         winrt::PackageDependencyLifetimeArtifactKind LifetimeArtifactKind();
-        void LifetimeArtifactKind(Microsoft::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind const& value);
+        void LifetimeArtifactKind(Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind const& value);
         hstring LifetimeArtifact();
         void LifetimeArtifact(hstring const& value);
 
@@ -29,7 +29,7 @@ namespace winrt::Microsoft::ApplicationModel::DynamicDependency::implementation
         hstring m_lifetimeArtifact;
     };
 }
-namespace winrt::Microsoft::ApplicationModel::DynamicDependency::factory_implementation
+namespace winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::factory_implementation
 {
     struct CreatePackageDependencyOptions : CreatePackageDependencyOptionsT<CreatePackageDependencyOptions, implementation::CreatePackageDependencyOptions>
     {

--- a/dev/DynamicDependency/M.AM.DD.PackageDependency.cpp
+++ b/dev/DynamicDependency/M.AM.DD.PackageDependency.cpp
@@ -4,7 +4,7 @@
 #include "pch.h"
 
 #include "M.AM.DD.PackageDependency.h"
-#include "Microsoft.ApplicationModel.DynamicDependency.PackageDependency.g.cpp"
+#include "Microsoft.Windows.ApplicationModel.DynamicDependency.PackageDependency.g.cpp"
 
 #include "M.AM.DD.PackageDependencyContext.h"
 
@@ -16,7 +16,7 @@
 
 #include <M.AM.Converters.h>
 
-namespace winrt::Microsoft::ApplicationModel::DynamicDependency::implementation
+namespace winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::implementation
 {
     PackageDependency::PackageDependency(hstring const& id) :
         m_id(id)
@@ -44,10 +44,10 @@ namespace winrt::Microsoft::ApplicationModel::DynamicDependency::implementation
         return winrt::make<implementation::PackageDependency>(id);
     }
 
-    winrt::PackageDependency PackageDependency::Create(hstring const& packageFamilyName, Windows::ApplicationModel::PackageVersion const& minVersion)
+    winrt::PackageDependency PackageDependency::Create(hstring const& packageFamilyName, winrt::Windows::ApplicationModel::PackageVersion const& minVersion)
     {
         auto tokenUser{ wil::get_token_information<TOKEN_USER>(GetCurrentThreadEffectiveToken()) };
-        const auto mddMinVersion{ ::Microsoft::ApplicationModel::DynamicDependency::ToVersion(minVersion) };
+        const auto mddMinVersion{ ::Microsoft::Windows::ApplicationModel::DynamicDependency::ToVersion(minVersion) };
         const auto mddArchitectures{ MddPackageDependencyProcessorArchitectures::None };
         const auto mddLifetimeKind{ MddPackageDependencyLifetimeKind::Process };
         const PCWSTR mddLifetimeArtifact{};
@@ -55,24 +55,24 @@ namespace winrt::Microsoft::ApplicationModel::DynamicDependency::implementation
         return Create(tokenUser->User.Sid, packageFamilyName.c_str(), mddMinVersion, mddArchitectures, mddLifetimeKind, mddLifetimeArtifact, mddOptions);
     }
 
-    winrt::PackageDependency PackageDependency::Create(hstring const& packageFamilyName, Windows::ApplicationModel::PackageVersion const& minVersion, winrt::CreatePackageDependencyOptions const& options)
+    winrt::PackageDependency PackageDependency::Create(hstring const& packageFamilyName, winrt::Windows::ApplicationModel::PackageVersion const& minVersion, winrt::CreatePackageDependencyOptions const& options)
     {
         auto tokenUser{ wil::get_token_information<TOKEN_USER>(GetCurrentThreadEffectiveToken()) };
-        const auto mddMinVersion{ ::Microsoft::ApplicationModel::DynamicDependency::ToVersion(minVersion) };
-        const auto mddArchitectures{ ::Microsoft::ApplicationModel::DynamicDependency::ToArchitectures(options.Architectures()) };
-        const auto mddLifetimeKind{ ::Microsoft::ApplicationModel::DynamicDependency::ToLifetimeKind(options.LifetimeArtifactKind()) };
+        const auto mddMinVersion{ ::Microsoft::Windows::ApplicationModel::DynamicDependency::ToVersion(minVersion) };
+        const auto mddArchitectures{ ::Microsoft::Windows::ApplicationModel::DynamicDependency::ToArchitectures(options.Architectures()) };
+        const auto mddLifetimeKind{ ::Microsoft::Windows::ApplicationModel::DynamicDependency::ToLifetimeKind(options.LifetimeArtifactKind()) };
         const auto mddLifetimeArtifact{ options.LifetimeArtifact().c_str() };
-        const auto mddOptions{ ::Microsoft::ApplicationModel::DynamicDependency::ToCreateOptions(options) };
+        const auto mddOptions{ ::Microsoft::Windows::ApplicationModel::DynamicDependency::ToCreateOptions(options) };
         return Create(tokenUser->User.Sid, packageFamilyName.c_str(), mddMinVersion, mddArchitectures, mddLifetimeKind, mddLifetimeArtifact, mddOptions);
     }
 
-    winrt::PackageDependency PackageDependency::CreateForSystem(hstring const& packageFamilyName, Windows::ApplicationModel::PackageVersion const& minVersion, winrt::CreatePackageDependencyOptions const& options)
+    winrt::PackageDependency PackageDependency::CreateForSystem(hstring const& packageFamilyName, winrt::Windows::ApplicationModel::PackageVersion const& minVersion, winrt::CreatePackageDependencyOptions const& options)
     {
-        const auto mddMinVersion{ ::Microsoft::ApplicationModel::DynamicDependency::ToVersion(minVersion) };
-        const auto mddArchitectures{ ::Microsoft::ApplicationModel::DynamicDependency::ToArchitectures(options.Architectures()) };
-        const auto mddLifetimeKind{ ::Microsoft::ApplicationModel::DynamicDependency::ToLifetimeKind(options.LifetimeArtifactKind()) };
+        const auto mddMinVersion{ ::Microsoft::Windows::ApplicationModel::DynamicDependency::ToVersion(minVersion) };
+        const auto mddArchitectures{ ::Microsoft::Windows::ApplicationModel::DynamicDependency::ToArchitectures(options.Architectures()) };
+        const auto mddLifetimeKind{ ::Microsoft::Windows::ApplicationModel::DynamicDependency::ToLifetimeKind(options.LifetimeArtifactKind()) };
         const auto mddLifetimeArtifact{ options.LifetimeArtifact().c_str() };
-        auto mddOptions{ ::Microsoft::ApplicationModel::DynamicDependency::ToCreateOptions(options, MddCreatePackageDependencyOptions::ScopeIsSystem) };
+        auto mddOptions{ ::Microsoft::Windows::ApplicationModel::DynamicDependency::ToCreateOptions(options, MddCreatePackageDependencyOptions::ScopeIsSystem) };
         return Create(nullptr, packageFamilyName.c_str(), mddMinVersion, mddArchitectures, mddLifetimeKind, mddLifetimeArtifact, mddOptions);
     }
 
@@ -97,10 +97,10 @@ namespace winrt::Microsoft::ApplicationModel::DynamicDependency::implementation
         return context;
     }
 
-    winrt::PackageDependencyContext PackageDependency::Add(Microsoft::ApplicationModel::DynamicDependency::AddPackageDependencyOptions const& options)
+    winrt::PackageDependencyContext PackageDependency::Add(Microsoft::Windows::ApplicationModel::DynamicDependency::AddPackageDependencyOptions const& options)
     {
         const auto rank{ options.Rank() };
-        const auto mddOptions{ ::Microsoft::ApplicationModel::DynamicDependency::ToAddOptions(options) };
+        const auto mddOptions{ ::Microsoft::Windows::ApplicationModel::DynamicDependency::ToAddOptions(options) };
         wil::unique_package_dependency_context packageDependencyContext;
         winrt::check_hresult(MddAddPackageDependency(m_id.c_str(), rank, mddOptions, &packageDependencyContext, nullptr));
         auto context{ winrt::make<implementation::PackageDependencyContext>(packageDependencyContext.get()) };

--- a/dev/DynamicDependency/M.AM.DD.PackageDependency.h
+++ b/dev/DynamicDependency/M.AM.DD.PackageDependency.h
@@ -3,11 +3,11 @@
 
 #pragma once
 
-#include "Microsoft.ApplicationModel.DynamicDependency.PackageDependency.g.h"
+#include "Microsoft.Windows.ApplicationModel.DynamicDependency.PackageDependency.g.h"
 
 #include "winrt_namespaces.h"
 
-namespace winrt::Microsoft::ApplicationModel::DynamicDependency::implementation
+namespace winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::implementation
 {
     struct PackageDependency : PackageDependencyT<PackageDependency>
     {
@@ -17,13 +17,13 @@ namespace winrt::Microsoft::ApplicationModel::DynamicDependency::implementation
 
         static winrt::PackageDependency GetFromId(hstring const& id);
         static winrt::PackageDependency GetFromIdForSystem(hstring const& id);
-        static winrt::PackageDependency Create(hstring const& packageFamilyName, Windows::ApplicationModel::PackageVersion const& minVersion);
-        static winrt::PackageDependency Create(hstring const& packageFamilyName, Windows::ApplicationModel::PackageVersion const& minVersion, winrt::CreatePackageDependencyOptions const& options);
-        static winrt::PackageDependency CreateForSystem(hstring const& packageFamilyName, Windows::ApplicationModel::PackageVersion const& minVersion, winrt::CreatePackageDependencyOptions const& options);
+        static winrt::PackageDependency Create(hstring const& packageFamilyName, winrt::Windows::ApplicationModel::PackageVersion const& minVersion);
+        static winrt::PackageDependency Create(hstring const& packageFamilyName, winrt::Windows::ApplicationModel::PackageVersion const& minVersion, winrt::CreatePackageDependencyOptions const& options);
+        static winrt::PackageDependency CreateForSystem(hstring const& packageFamilyName, winrt::Windows::ApplicationModel::PackageVersion const& minVersion, winrt::CreatePackageDependencyOptions const& options);
         hstring Id();
         void Delete();
         winrt::PackageDependencyContext Add();
-        winrt::PackageDependencyContext Add(Microsoft::ApplicationModel::DynamicDependency::AddPackageDependencyOptions const& options);
+        winrt::PackageDependencyContext Add(Microsoft::Windows::ApplicationModel::DynamicDependency::AddPackageDependencyOptions const& options);
 
     private:
         static winrt::PackageDependency Create(
@@ -39,7 +39,7 @@ namespace winrt::Microsoft::ApplicationModel::DynamicDependency::implementation
         hstring m_id;
     };
 }
-namespace winrt::Microsoft::ApplicationModel::DynamicDependency::factory_implementation
+namespace winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::factory_implementation
 {
     struct PackageDependency : PackageDependencyT<PackageDependency, implementation::PackageDependency>
     {

--- a/dev/DynamicDependency/M.AM.DD.PackageDependencyContext.cpp
+++ b/dev/DynamicDependency/M.AM.DD.PackageDependencyContext.cpp
@@ -4,18 +4,18 @@
 #include "pch.h"
 
 #include "M.AM.DD.PackageDependencyContext.h"
-#include "Microsoft.ApplicationModel.DynamicDependency.PackageDependencyContext.g.cpp"
+#include "Microsoft.Windows.ApplicationModel.DynamicDependency.PackageDependencyContext.g.cpp"
 
 #include <M.AM.Converters.h>
 
-namespace winrt::Microsoft::ApplicationModel::DynamicDependency::implementation
+namespace winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::implementation
 {
-    PackageDependencyContext::PackageDependencyContext(Microsoft::ApplicationModel::DynamicDependency::PackageDependencyContextId const& contextId) :
+    PackageDependencyContext::PackageDependencyContext(Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyContextId const& contextId) :
         m_contextId(contextId)
     {
     }
     PackageDependencyContext::PackageDependencyContext(MDD_PACKAGEDEPENDENCY_CONTEXT context) :
-        m_contextId(::Microsoft::ApplicationModel::DynamicDependency::ToContextId(context))
+        m_contextId(::Microsoft::Windows::ApplicationModel::DynamicDependency::ToContextId(context))
     {
     }
     winrt::PackageDependencyContextId PackageDependencyContext::ContextId()
@@ -26,7 +26,7 @@ namespace winrt::Microsoft::ApplicationModel::DynamicDependency::implementation
     hstring PackageDependencyContext::PackageDependencyId()
     {
         wil::unique_process_heap_string id;
-        winrt::check_hresult(MddGetIdForPackageDependencyContext(::Microsoft::ApplicationModel::DynamicDependency::ToContext(m_contextId), wil::out_param(id)));
+        winrt::check_hresult(MddGetIdForPackageDependencyContext(::Microsoft::Windows::ApplicationModel::DynamicDependency::ToContext(m_contextId), wil::out_param(id)));
         return winrt::hstring(id.get());
     }
 
@@ -40,6 +40,6 @@ namespace winrt::Microsoft::ApplicationModel::DynamicDependency::implementation
 
     void PackageDependencyContext::Remove()
     {
-        MddRemovePackageDependency(::Microsoft::ApplicationModel::DynamicDependency::ToContext(m_contextId));
+        MddRemovePackageDependency(::Microsoft::Windows::ApplicationModel::DynamicDependency::ToContext(m_contextId));
     }
 }

--- a/dev/DynamicDependency/M.AM.DD.PackageDependencyContext.h
+++ b/dev/DynamicDependency/M.AM.DD.PackageDependencyContext.h
@@ -3,20 +3,20 @@
 
 #pragma once
 
-#include "Microsoft.ApplicationModel.DynamicDependency.PackageDependencyContext.g.h"
+#include "Microsoft.Windows.ApplicationModel.DynamicDependency.PackageDependencyContext.g.h"
 
 #include "winrt_namespaces.h"
 
 #include <MsixDynamicDependency.h>
 
-namespace winrt::Microsoft::ApplicationModel::DynamicDependency::implementation
+namespace winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::implementation
 {
     struct PackageDependencyContext : PackageDependencyContextT<PackageDependencyContext>
     {
         PackageDependencyContext() = default;
 
         PackageDependencyContext(MDD_PACKAGEDEPENDENCY_CONTEXT context);
-        PackageDependencyContext(Microsoft::ApplicationModel::DynamicDependency::PackageDependencyContextId const& contextId);
+        PackageDependencyContext(Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyContextId const& contextId);
 
         winrt::PackageDependencyContextId ContextId();
         hstring PackageDependencyId();
@@ -27,7 +27,7 @@ namespace winrt::Microsoft::ApplicationModel::DynamicDependency::implementation
         winrt::PackageDependencyContextId m_contextId;
     };
 }
-namespace winrt::Microsoft::ApplicationModel::DynamicDependency::factory_implementation
+namespace winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::factory_implementation
 {
     struct PackageDependencyContext : PackageDependencyContextT<PackageDependencyContext, implementation::PackageDependencyContext>
     {

--- a/dev/DynamicDependency/M.AM.DD.PackageDependencyRank.cpp
+++ b/dev/DynamicDependency/M.AM.DD.PackageDependencyRank.cpp
@@ -4,11 +4,11 @@
 #include "pch.h"
 
 #include "M.AM.DD.PackageDependencyRank.h"
-#include "Microsoft.ApplicationModel.DynamicDependency.PackageDependencyRank.g.cpp"
+#include "Microsoft.Windows.ApplicationModel.DynamicDependency.PackageDependencyRank.g.cpp"
 
 #include <MsixDynamicDependency.h>
 
-namespace winrt::Microsoft::ApplicationModel::DynamicDependency::implementation
+namespace winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::implementation
 {
     int32_t PackageDependencyRank::Default()
     {

--- a/dev/DynamicDependency/M.AM.DD.PackageDependencyRank.h
+++ b/dev/DynamicDependency/M.AM.DD.PackageDependencyRank.h
@@ -3,9 +3,9 @@
 
 #pragma once
 
-#include "Microsoft.ApplicationModel.DynamicDependency.PackageDependencyRank.g.h"
+#include "Microsoft.Windows.ApplicationModel.DynamicDependency.PackageDependencyRank.g.h"
 
-namespace winrt::Microsoft::ApplicationModel::DynamicDependency::implementation
+namespace winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::implementation
 {
     struct PackageDependencyRank
     {
@@ -14,7 +14,7 @@ namespace winrt::Microsoft::ApplicationModel::DynamicDependency::implementation
         static int32_t Default();
     };
 }
-namespace winrt::Microsoft::ApplicationModel::DynamicDependency::factory_implementation
+namespace winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::factory_implementation
 {
     struct PackageDependencyRank : PackageDependencyRankT<PackageDependencyRank, implementation::PackageDependencyRank>
     {

--- a/dev/DynamicDependency/M.AM.DynamicDependency.idl
+++ b/dev/DynamicDependency/M.AM.DynamicDependency.idl
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace Microsoft.ApplicationModel.DynamicDependency
+namespace Microsoft.Windows.ApplicationModel.DynamicDependency
 {
     /// CPU architectures to optionally filter available packages against a package dependency.
     /// These generally correspond to processor architecture types supported by MSIX.

--- a/dev/DynamicDependency/winrt_namespaces.h
+++ b/dev/DynamicDependency/winrt_namespaces.h
@@ -4,6 +4,6 @@
 #pragma once
 
 namespace winrt
-{                      
-    using namespace winrt::Microsoft::ApplicationModel::DynamicDependency;
+{
+    using namespace winrt::Microsoft::Windows::ApplicationModel::DynamicDependency;
 }

--- a/specs/dynamicdependencies/DynamicDependencies.md
+++ b/specs/dynamicdependencies/DynamicDependencies.md
@@ -1292,7 +1292,7 @@ STDAPI MddLifetimeManagementGC() noexcept;
 ## 6.2. WinRT API
 
 ```c# (but really MIDL3)
-namespace Microsoft.ApplicationModel.DynamicDependency
+namespace Microsoft.Windows.ApplicationModel.DynamicDependency
 {
 /// CPU architectures to optionally filter available packages against a package dependency.
 /// These generally correspond to processor architecture types supported by MSIX.

--- a/specs/dynamicdependencies/sample-1.md
+++ b/specs/dynamicdependencies/sample-1.md
@@ -57,7 +57,7 @@ HRESULT ManageMuffins(int& countOfMuffinsManaged)
 ## WinRT
 
 ```c#
-using Microsoft.ApplicationModel.DynamicDependency;
+using Microsoft.Windows.ApplicationModel.DynamicDependency;
 using System.Reflection;
 using Windows.ApplicationModel;
 

--- a/specs/dynamicdependencies/sample-3.md
+++ b/specs/dynamicdependencies/sample-3.md
@@ -49,7 +49,7 @@ int __cdecl wmain(_In_ int argc, _In_reads_(argc) WCHAR * argv[])
 ## WinRT
 
 ```c#
-using Microsoft.ApplicationModel.DynamicDependency;
+using Microsoft.Windows.ApplicationModel.DynamicDependency;
 using Windows.ApplicationModel;
 
 namespace MyApp

--- a/specs/dynamicdependencies/sample-4.md
+++ b/specs/dynamicdependencies/sample-4.md
@@ -130,7 +130,7 @@ HRESULT LoadPackageDependencyId(_In_ PCWSTR what, wil::unique_ptr<WCHAR[]>& pack
 ## WinRT
 
 ```c#
-using Microsoft.ApplicationModel.DynamicDependency;
+using Microsoft.Windows.ApplicationModel.DynamicDependency;
 using Windows.ApplicationModel;
 
 namespace LolzKitten

--- a/specs/dynamicdependencies/sample-5.md
+++ b/specs/dynamicdependencies/sample-5.md
@@ -48,7 +48,7 @@ HRESULT LoadPackageDependencyId(_In_ PCWSTR what, wil::unique_ptr<WCHAR[]>& pack
 ## WinRT
 
 ```c#
-using Microsoft.ApplicationModel.DynamicDependency;
+using Microsoft.Windows.ApplicationModel.DynamicDependency;
 using System.Reflection;
 
 namespace LolzKitten

--- a/specs/dynamicdependencies/sample-6.md
+++ b/specs/dynamicdependencies/sample-6.md
@@ -60,7 +60,7 @@ HRESULT SavePackageDependencyId(_In_ PCWSTR packageDependencyId)
 ## WinRT
 
 ```c#
-using Microsoft.ApplicationModel.DynamicDependency;
+using Microsoft.Windows.ApplicationModel.DynamicDependency;
 using Windows.ApplicationModel;
 
 namespace LolzKitten

--- a/specs/dynamicdependencies/sample-7.md
+++ b/specs/dynamicdependencies/sample-7.md
@@ -54,7 +54,7 @@ HRESULT LoadPackageDependencyId(_In_ PCWSTR what, wil::unique_ptr<WCHAR[]>& pack
 ## WinRT
 
 ```c#
-using Microsoft.ApplicationModel.DynamicDependency;
+using Microsoft.Windows.ApplicationModel.DynamicDependency;
 
 var g_packageDependencyContexts = new Dictionary<string, PackageDependencyContext>();
 

--- a/specs/dynamicdependencies/sample-8.md
+++ b/specs/dynamicdependencies/sample-8.md
@@ -35,7 +35,7 @@ HRESULT LoadPackageDependencyId(_In_ PCWSTR what, wil::unique_ptr<WCHAR[]>& pack
 ## WinRT
 
 ```c#
-using Microsoft.ApplicationModel.DynamicDependency;
+using Microsoft.Windows.ApplicationModel.DynamicDependency;
 
 var g_packageDependencyContexts = new Dictionary<string, PackageDependencyContext>();
 

--- a/test/DynamicDependency/Test_WinRT/Create_FilePathLifetime_NoExist.cpp
+++ b/test/DynamicDependency/Test_WinRT/Create_FilePathLifetime_NoExist.cpp
@@ -34,7 +34,7 @@ void Test::DynamicDependency::Test_WinRT::Create_FilePathLifetime_NoExist()
 
     try
     {
-        const auto lifetimeKind{ winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind::FilePath };
+        const auto lifetimeKind{ winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind::FilePath };
         auto packageDependency_FrameworkMathAdd{ _Create_FrameworkMathAdd(HRESULT_FROM_WIN32(ERROR_CONTEXT_EXPIRED), lifetimeKind, lifetimeArtifactFilename.c_str()) };
         auto message{ wil::str_printf<wil::unique_process_heap_string>(L"Expected exception (value=0x%X ERROR_CONTEXT_EXPIRED) didn't occur", HRESULT_FROM_WIN32(ERROR_CONTEXT_EXPIRED)) };
         VERIFY_FAIL(message.get());

--- a/test/DynamicDependency/Test_WinRT/Create_RegistryLifetime_NoExist.cpp
+++ b/test/DynamicDependency/Test_WinRT/Create_RegistryLifetime_NoExist.cpp
@@ -33,7 +33,7 @@ void Test::DynamicDependency::Test_WinRT::Create_RegistryLifetime_NoExist()
 
     try
     {
-        const auto lifetimeKind{ winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind::RegistryKey };
+        const auto lifetimeKind{ winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind::RegistryKey };
         auto packageDependency_FrameworkMathAdd{ _Create_FrameworkMathAdd(HRESULT_FROM_WIN32(ERROR_CONTEXT_EXPIRED), lifetimeKind, lifetimeArtifactRegistryKey.c_str()) };
         auto message{ wil::str_printf<wil::unique_process_heap_string>(L"Expected exception (value=0x%X ERROR_CONTEXT_EXPIRED) didn't occur", HRESULT_FROM_WIN32(ERROR_CONTEXT_EXPIRED)) };
         VERIFY_FAIL(message.get());

--- a/test/DynamicDependency/Test_WinRT/DynamicDependency_Test_WinRT.vcxproj
+++ b/test/DynamicDependency/Test_WinRT/DynamicDependency_Test_WinRT.vcxproj
@@ -344,8 +344,8 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.ApplicationModel.DynamicDependency">
-      <HintPath>$(OutDir)\..\ProjectReunion_DLL\Microsoft.ApplicationModel.DynamicDependency.winmd</HintPath>
+    <Reference Include="Microsoft.Windows.ApplicationModel.DynamicDependency">
+      <HintPath>$(OutDir)\..\ProjectReunion_DLL\Microsoft.Windows.ApplicationModel.DynamicDependency.winmd</HintPath>
       <IsWinMDFile>true</IsWinMDFile>
     </Reference>
   </ItemGroup>

--- a/test/DynamicDependency/Test_WinRT/Test_WinRT.cpp
+++ b/test/DynamicDependency/Test_WinRT/Test_WinRT.cpp
@@ -3,7 +3,7 @@
 
 #include "pch.h"
 
-#include <winrt/Microsoft.ApplicationModel.DynamicDependency.h>
+#include <winrt/Microsoft.Windows.ApplicationModel.DynamicDependency.h>
 
 #include <Math.Add.h>
 #include <Math.Multiply.h>
@@ -77,7 +77,7 @@ void Test::DynamicDependency::Test_WinRT::Create_Delete()
 {
     const winrt::hstring packageFamilyName{ TP::FrameworkMathAdd::c_PackageFamilyName };
     const winrt::Windows::ApplicationModel::PackageVersion minVersion{};
-    auto packageDependency{ winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependency::Create(packageFamilyName, minVersion) };
+    auto packageDependency{ winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependency::Create(packageFamilyName, minVersion) };
 
     packageDependency.Delete();
 }
@@ -85,14 +85,14 @@ void Test::DynamicDependency::Test_WinRT::Create_Delete()
 void Test::DynamicDependency::Test_WinRT::GetFromId_Empty()
 {
     winrt::hstring packageDependencyId;
-    auto packageDependency{ winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependency::GetFromId(packageDependencyId) };
+    auto packageDependency{ winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependency::GetFromId(packageDependencyId) };
     VERIFY_IS_TRUE(!packageDependency);
 }
 
 void Test::DynamicDependency::Test_WinRT::GetFromId_NotFound()
 {
     winrt::hstring packageDependencyId{ L"This.Does.Not.Exist" };
-    auto packageDependency{ winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependency::GetFromId(packageDependencyId) };
+    auto packageDependency{ winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependency::GetFromId(packageDependencyId) };
     VERIFY_IS_TRUE(!packageDependency);
 }
 
@@ -216,14 +216,14 @@ void Test::DynamicDependency::Test_WinRT::VerifyPackageDependency(
 }
 
 void Test::DynamicDependency::Test_WinRT::VerifyPackageDependency(
-    const winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependency& packageDependency,
+    const winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependency& packageDependency,
     const HRESULT expectedHR)
 {
     VerifyPackageDependency(packageDependency.Id().c_str(), expectedHR);
 }
 
 void Test::DynamicDependency::Test_WinRT::VerifyPackageDependency(
-    const winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependency& packageDependency,
+    const winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependency& packageDependency,
     const HRESULT expectedHR,
     const winrt::hstring& expectedPackageFullName)
 {
@@ -358,32 +358,32 @@ int Test::DynamicDependency::Test_WinRT::FindPackageFullNameInPackageInfoArray(
     return -1;
 }
 
-winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependency Test::DynamicDependency::Test_WinRT::_Create(
+winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependency Test::DynamicDependency::Test_WinRT::_Create(
     const winrt::hstring& packageFamilyName,
-    const winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind lifetimeKind,
+    const winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind lifetimeKind,
     PCWSTR lifetimeArtifact)
 {
     return _Create(S_OK, packageFamilyName, lifetimeKind, lifetimeArtifact);
 }
 
-winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependency Test::DynamicDependency::Test_WinRT::_Create(
+winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependency Test::DynamicDependency::Test_WinRT::_Create(
     const HRESULT expectedHR,
     const winrt::hstring& packageFamilyName,
-    const winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind lifetimeKind,
+    const winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind lifetimeKind,
     PCWSTR lifetimeArtifact)
 {
-    const winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures architectures{};
+    const winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures architectures{};
     return _Create(expectedHR, packageFamilyName, architectures, lifetimeKind, lifetimeArtifact);
 }
 
-winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependency Test::DynamicDependency::Test_WinRT::_Create(
+winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependency Test::DynamicDependency::Test_WinRT::_Create(
     const HRESULT expectedHR,
     const winrt::hstring& packageFamilyName,
-    const winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures architectures,
-    const winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind lifetimeKind,
+    const winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures architectures,
+    const winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind lifetimeKind,
     PCWSTR lifetimeArtifact)
 {
-    winrt::Microsoft::ApplicationModel::DynamicDependency::CreatePackageDependencyOptions options;
+    winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::CreatePackageDependencyOptions options;
     options.Architectures(architectures);
     options.LifetimeArtifactKind(lifetimeKind);
     if (lifetimeArtifact)
@@ -393,15 +393,15 @@ winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependency Test::D
     return _Create(expectedHR, packageFamilyName, options);
 }
 
-winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependency Test::DynamicDependency::Test_WinRT::_Create(
+winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependency Test::DynamicDependency::Test_WinRT::_Create(
     const HRESULT expectedHR,
     const winrt::hstring& packageFamilyName,
-    winrt::Microsoft::ApplicationModel::DynamicDependency::CreatePackageDependencyOptions& options)
+    winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::CreatePackageDependencyOptions& options)
 {
     try
     {
         winrt::Windows::ApplicationModel::PackageVersion minVersion{};
-        auto packageDependency{ winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependency::Create(packageFamilyName, minVersion, options) };
+        auto packageDependency{ winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependency::Create(packageFamilyName, minVersion, options) };
         VERIFY_ARE_EQUAL(expectedHR, S_OK);
         return packageDependency;
     }
@@ -412,78 +412,78 @@ winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependency Test::D
     }
 }
 
-winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependency Test::DynamicDependency::Test_WinRT::_Create_ProjectReunionFramework(
-    const winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind lifetimeKind,
+winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependency Test::DynamicDependency::Test_WinRT::_Create_ProjectReunionFramework(
+    const winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind lifetimeKind,
     PCWSTR lifetimeArtifact)
 {
     return _Create(TP::ProjectReunionFramework::c_PackageFamilyName, lifetimeKind, lifetimeArtifact);
 }
 
-winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependency Test::DynamicDependency::Test_WinRT::_Create_FrameworkMathAdd()
+winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependency Test::DynamicDependency::Test_WinRT::_Create_FrameworkMathAdd()
 {
-    const winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind lifetimeKind{ winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind::Process };
+    const winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind lifetimeKind{ winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind::Process };
     PCWSTR lifetimeArtifact{};
     return _Create(S_OK, TP::FrameworkMathAdd::c_PackageFamilyName, lifetimeKind, lifetimeArtifact);
 }
 
-winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependency Test::DynamicDependency::Test_WinRT::_Create_FrameworkMathAdd(
-    const winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind lifetimeKind,
+winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependency Test::DynamicDependency::Test_WinRT::_Create_FrameworkMathAdd(
+    const winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind lifetimeKind,
     PCWSTR lifetimeArtifact)
 {
     return _Create(TP::FrameworkMathAdd::c_PackageFamilyName, lifetimeKind, lifetimeArtifact);
 }
 
-winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependency Test::DynamicDependency::Test_WinRT::_Create_FrameworkMathAdd(
-    const winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures architectures,
-    const winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind lifetimeKind,
+winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependency Test::DynamicDependency::Test_WinRT::_Create_FrameworkMathAdd(
+    const winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures architectures,
+    const winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind lifetimeKind,
     PCWSTR lifetimeArtifact)
 {
     return _Create(S_OK, TP::FrameworkMathAdd::c_PackageFamilyName, architectures, lifetimeKind, lifetimeArtifact);
 }
 
-winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependency Test::DynamicDependency::Test_WinRT::_Create_FrameworkMathAdd(
+winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependency Test::DynamicDependency::Test_WinRT::_Create_FrameworkMathAdd(
     const HRESULT expectedHR,
-    const winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind lifetimeKind,
+    const winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind lifetimeKind,
     PCWSTR lifetimeArtifact)
 {
     return _Create(expectedHR, TP::FrameworkMathAdd::c_PackageFamilyName, lifetimeKind, lifetimeArtifact);
 }
 
-winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependency Test::DynamicDependency::Test_WinRT::_Create_FrameworkMathAdd(
-    winrt::Microsoft::ApplicationModel::DynamicDependency::CreatePackageDependencyOptions& options)
+winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependency Test::DynamicDependency::Test_WinRT::_Create_FrameworkMathAdd(
+    winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::CreatePackageDependencyOptions& options)
 {
     return _Create(S_OK, TP::FrameworkMathAdd::c_PackageFamilyName, options);
 }
 
-winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyContext Test::DynamicDependency::Test_WinRT::_Add(
-    winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependency packageDependency)
+winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyContext Test::DynamicDependency::Test_WinRT::_Add(
+    winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependency packageDependency)
 {
     return _Add(S_OK, packageDependency);
 }
 
-winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyContext Test::DynamicDependency::Test_WinRT::_Add(
+winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyContext Test::DynamicDependency::Test_WinRT::_Add(
     const HRESULT expectedHR,
-    winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependency packageDependency)
+    winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependency packageDependency)
 {
-    const auto rank{ winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyRank::Default() };
+    const auto rank{ winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyRank::Default() };
     return _Add(expectedHR, packageDependency, rank);
 }
 
-winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyContext Test::DynamicDependency::Test_WinRT::_Add(
-    winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependency packageDependency,
+winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyContext Test::DynamicDependency::Test_WinRT::_Add(
+    winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependency packageDependency,
     const INT32 rank)
 {
     return _Add(S_OK, packageDependency, rank);
 }
 
-winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyContext Test::DynamicDependency::Test_WinRT::_Add(
+winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyContext Test::DynamicDependency::Test_WinRT::_Add(
     const HRESULT expectedHR,
-    winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependency packageDependency,
+    winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependency packageDependency,
     const INT32 rank)
 {
     try
     {
-        winrt::Microsoft::ApplicationModel::DynamicDependency::AddPackageDependencyOptions options;
+        winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::AddPackageDependencyOptions options;
         options.Rank(rank);
         auto packageDependencyContext{ packageDependency.Add(options) };
         VERIFY_ARE_EQUAL(expectedHR, S_OK);
@@ -605,16 +605,16 @@ std::wstring Test::DynamicDependency::Test_WinRT::GetPathEnvironmentVariableMinu
     return GetPathEnvironmentVariableMinusPathPrefix(packagePath_ProjectReunionFramework);
 }
 
-winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures Test::DynamicDependency::Test_WinRT::GetCurrentArchitectureAsFilter()
+winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures Test::DynamicDependency::Test_WinRT::GetCurrentArchitectureAsFilter()
 {
 #if defined(_M_ARM)
-    return winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures::Arm;
+    return winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures::Arm;
 #elif defined(_M_ARM64)
-    return winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures::Arm64;
+    return winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures::Arm64;
 #elif defined(_M_IX86)
-    return winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures::X86;
+    return winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures::X86;
 #elif defined(_M_X64)
-    return winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures::X64;
+    return winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures::X64;
 #else
 #   error "Unknown processor architecture"
 #endif

--- a/test/DynamicDependency/Test_WinRT/Test_WinRT.h
+++ b/test/DynamicDependency/Test_WinRT/Test_WinRT.h
@@ -59,11 +59,11 @@ namespace Test::DynamicDependency
             const winrt::hstring& expectedPackageFullName);
 
         static void VerifyPackageDependency(
-            const winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependency& packageDependency,
+            const winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependency& packageDependency,
             const HRESULT expectedHR);
 
         static void VerifyPackageDependency(
-            const winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependency& packageDependency,
+            const winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependency& packageDependency,
             const HRESULT expectedHR,
             const winrt::hstring& expectedPackageFullName);
 
@@ -114,68 +114,68 @@ namespace Test::DynamicDependency
 
     private:
         // Overloads and conveniences for TryCreate to simplify test readability
-        winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependency _Create(
+        winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependency _Create(
             const winrt::hstring& packageFamilyName,
-            const winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind lifetimeKind = winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind::Process,
+            const winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind lifetimeKind = winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind::Process,
             PCWSTR lifetimeArtifact = nullptr);
 
-        winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependency _Create(
+        winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependency _Create(
             const HRESULT expectedHR,
             const winrt::hstring& packageFamilyName,
-            const winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind lifetimeKind = winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind::Process,
+            const winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind lifetimeKind = winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind::Process,
             PCWSTR lifetimeArtifact = nullptr);
 
-        winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependency _Create(
+        winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependency _Create(
             const HRESULT expectedHR,
             const winrt::hstring& packageFamilyName,
-            const winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures architectures,
-            const winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind lifetimeKind = winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind::Process,
+            const winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures architectures,
+            const winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind lifetimeKind = winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind::Process,
             PCWSTR lifetimeArtifact = nullptr);
 
-        winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependency _Create(
+        winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependency _Create(
             const HRESULT expectedHR,
     const winrt::hstring& packageFamilyName,
-            winrt::Microsoft::ApplicationModel::DynamicDependency::CreatePackageDependencyOptions& options);
+            winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::CreatePackageDependencyOptions& options);
 
-        winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependency _Create_ProjectReunionFramework(
-            const winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind lifetimeKind = winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind::Process,
+        winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependency _Create_ProjectReunionFramework(
+            const winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind lifetimeKind = winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind::Process,
             PCWSTR lifetimeArtifact = nullptr);
 
-        winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependency _Create_FrameworkMathAdd();
+        winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependency _Create_FrameworkMathAdd();
 
-        winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependency _Create_FrameworkMathAdd(
-            const winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind lifetimeKind,
+        winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependency _Create_FrameworkMathAdd(
+            const winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind lifetimeKind,
             PCWSTR lifetimeArtifact = nullptr);
 
-        winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependency _Create_FrameworkMathAdd(
-            const winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures architectures,
-            const winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind lifetimeKind = winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind::Process,
+        winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependency _Create_FrameworkMathAdd(
+            const winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures architectures,
+            const winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind lifetimeKind = winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind::Process,
             PCWSTR lifetimeArtifact = nullptr);
 
-        winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependency _Create_FrameworkMathAdd(
+        winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependency _Create_FrameworkMathAdd(
             const HRESULT expectedHR,
-            const winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind lifetimeKind = winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind::Process,
+            const winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind lifetimeKind = winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind::Process,
             PCWSTR lifetimeArtifact = nullptr);
 
-        winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependency _Create_FrameworkMathAdd(
-            winrt::Microsoft::ApplicationModel::DynamicDependency::CreatePackageDependencyOptions& options);
+        winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependency _Create_FrameworkMathAdd(
+            winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::CreatePackageDependencyOptions& options);
 
     private:
         // Overloads and conveniences for Add to simplify test readability
-        winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyContext _Add(
-            winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependency packageDependency);
+        winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyContext _Add(
+            winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependency packageDependency);
 
-        winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyContext _Add(
+        winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyContext _Add(
             const HRESULT expectedHR,
-            winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependency packageDependency);
+            winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependency packageDependency);
 
-        winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyContext _Add(
-            winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependency packageDependency,
+        winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyContext _Add(
+            winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependency packageDependency,
             const INT32 rank);
 
-        winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyContext _Add(
+        winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyContext _Add(
             const HRESULT expectedHR,
-            winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependency packageDependency,
+            winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependency packageDependency,
             const INT32 rank);
 
     private:
@@ -209,7 +209,7 @@ namespace Test::DynamicDependency
         static std::wstring GetPathEnvironmentVariableMinusProjectReunionFramework();
 
     private:
-        static winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures GetCurrentArchitectureAsFilter();
+        static winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures GetCurrentArchitectureAsFilter();
 
     private:
         static wil::unique_hmodule m_bootstrapDll;

--- a/test/DynamicDependency/Test_WinRT/Test_WinRT_Add_Rank_A0_B10.cpp
+++ b/test/DynamicDependency/Test_WinRT/Test_WinRT_Add_Rank_A0_B10.cpp
@@ -40,7 +40,7 @@ void Test::DynamicDependency::Test_WinRT::Add_Rank_A0_B10()
 
     // -- Add
 
-    winrt::Microsoft::ApplicationModel::DynamicDependency::AddPackageDependencyOptions addOptions{};
+    winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::AddPackageDependencyOptions addOptions{};
     addOptions.Rank(10);
     auto packageDependencyContext_FrameworkMathAdd{ packageDependency_FrameworkMathAdd.Add(addOptions) };
     VERIFY_IS_FALSE(!packageDependencyContext_FrameworkMathAdd);

--- a/test/DynamicDependency/Test_WinRT/Test_WinRT_Add_Rank_B-10_A0.cpp
+++ b/test/DynamicDependency/Test_WinRT/Test_WinRT_Add_Rank_B-10_A0.cpp
@@ -40,7 +40,7 @@ void Test::DynamicDependency::Test_WinRT::Add_Rank_Bneg10_A0()
 
     // -- Add
 
-    winrt::Microsoft::ApplicationModel::DynamicDependency::AddPackageDependencyOptions addOptions{};
+    winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::AddPackageDependencyOptions addOptions{};
     addOptions.Rank(-10);
     auto packageDependencyContext_FrameworkMathAdd{ packageDependency_FrameworkMathAdd.Add(addOptions) };
     VERIFY_IS_FALSE(!packageDependencyContext_FrameworkMathAdd);

--- a/test/DynamicDependency/Test_WinRT/Test_WinRT_Add_Rank_B0prepend_A0.cpp
+++ b/test/DynamicDependency/Test_WinRT/Test_WinRT_Add_Rank_B0prepend_A0.cpp
@@ -40,7 +40,7 @@ void Test::DynamicDependency::Test_WinRT::Add_Rank_B0prepend_A0()
 
     // -- Add
 
-    winrt::Microsoft::ApplicationModel::DynamicDependency::AddPackageDependencyOptions addOptions{};
+    winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::AddPackageDependencyOptions addOptions{};
     addOptions.PrependIfRankCollision(true);
     auto packageDependencyContext_FrameworkMathAdd{ packageDependency_FrameworkMathAdd.Add(addOptions) };
     VERIFY_IS_FALSE(!packageDependencyContext_FrameworkMathAdd);

--- a/test/DynamicDependency/Test_WinRT/Test_WinRT_Create_Add_Architectures_Current.cpp
+++ b/test/DynamicDependency/Test_WinRT/Test_WinRT_Create_Add_Architectures_Current.cpp
@@ -29,9 +29,9 @@ void Test::DynamicDependency::Test_WinRT::Create_Add_Architectures_Current()
     // -- Create
 
     // We're using the Neutral arhitecture as that's our test package's defined architecture.
-    // That's OK, what matters is we're not using winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures::None
+    // That's OK, what matters is we're not using winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures::None
     // so we exercise the not-default-whatever-deemed-appropriate architecture codepath.
-    auto architectures{ winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures::Neutral };
+    auto architectures{ winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures::Neutral };
     auto packageDependency_FrameworkMathAdd{ _Create_FrameworkMathAdd(architectures) };
     VERIFY_IS_FALSE(!packageDependency_FrameworkMathAdd);
     auto packageDependencyId_FrameworkMathAdd{ packageDependency_FrameworkMathAdd.Id() };

--- a/test/DynamicDependency/Test_WinRT/Test_WinRT_Create_Add_Architectures_Explicit.cpp
+++ b/test/DynamicDependency/Test_WinRT/Test_WinRT_Create_Add_Architectures_Explicit.cpp
@@ -32,11 +32,11 @@ void Test::DynamicDependency::Test_WinRT::Create_Add_Architectures_Explicit()
     // That's OK, what matters is we're not using PackageDependencyProcessorArchitectures::None
     // so we exercise the not-default-whatever-deemed-appropriate architecture codepath.
     auto architectures{
-        winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures::Neutral |
-        winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures::X86 |
-        winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures::X64 |
-        winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures::Arm |
-        winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures::Arm64
+        winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures::Neutral |
+        winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures::X86 |
+        winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures::X64 |
+        winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures::Arm |
+        winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyProcessorArchitectures::Arm64
     };
     auto packageDependency_FrameworkMathAdd{ _Create_FrameworkMathAdd(architectures) };
     VERIFY_IS_FALSE(!packageDependency_FrameworkMathAdd);

--- a/test/DynamicDependency/Test_WinRT/Test_WinRT_Create_DoNotVerifyDependencyResolution.cpp
+++ b/test/DynamicDependency/Test_WinRT/Test_WinRT_Create_DoNotVerifyDependencyResolution.cpp
@@ -32,7 +32,7 @@ void Test::DynamicDependency::Test_WinRT::Create_DoNotVerifyDependencyResolution
     TP::RemovePackage_FrameworkMathAdd();
     VERIFY_IS_FALSE(TP::IsPackageRegistered(Test::Packages::FrameworkMathAdd::c_PackageFullName));
 
-    winrt::Microsoft::ApplicationModel::DynamicDependency::CreatePackageDependencyOptions createOptions{};
+    winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::CreatePackageDependencyOptions createOptions{};
     createOptions.VerifyDependencyResolution(false);
     auto packageDependency_FrameworkMathAdd{ _Create_FrameworkMathAdd(createOptions) };
     VERIFY_IS_FALSE(!packageDependency_FrameworkMathAdd);

--- a/test/DynamicDependency/Test_WinRT/Test_WinRT_FullLifecycle_FilePathLifetime_Frameworks_2.cpp
+++ b/test/DynamicDependency/Test_WinRT/Test_WinRT_FullLifecycle_FilePathLifetime_Frameworks_2.cpp
@@ -34,7 +34,7 @@ void Test::DynamicDependency::Test_WinRT::FullLifecycle_FilePathLifetime_Framewo
     VERIFY_IS_TRUE(lifetimeArtifactFile.is_valid());
     VERIFY_IS_TRUE(std::filesystem::exists(lifetimeArtifactFilename));
 
-    const auto lifetimeArtifactKind{ winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind::FilePath };
+    const auto lifetimeArtifactKind{ winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind::FilePath };
     auto packageDependency_FrameworkMathAdd{ _Create_FrameworkMathAdd(lifetimeArtifactKind, lifetimeArtifactFilename.c_str()) };
     VERIFY_IS_FALSE(!packageDependency_FrameworkMathAdd);
     auto packageDependencyId_FrameworkMathAdd{ packageDependency_FrameworkMathAdd.Id() };

--- a/test/DynamicDependency/Test_WinRT/Test_WinRT_FullLifecycle_RegistryLifetime_Frameworks_2.cpp
+++ b/test/DynamicDependency/Test_WinRT/Test_WinRT_FullLifecycle_RegistryLifetime_Frameworks_2.cpp
@@ -34,7 +34,7 @@ void Test::DynamicDependency::Test_WinRT::FullLifecycle_RegistryLifetime_Framewo
         VERIFY_IS_TRUE(lifetimeArtifactKey.is_valid());
     }
 
-    const auto lifetimeArtifactKind{ winrt::Microsoft::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind::RegistryKey};
+    const auto lifetimeArtifactKind{ winrt::Microsoft::Windows::ApplicationModel::DynamicDependency::PackageDependencyLifetimeArtifactKind::RegistryKey};
     auto packageDependency_FrameworkMathAdd{ _Create_FrameworkMathAdd(lifetimeArtifactKind, lifetimeArtifactRegistryKey.c_str()) };
     VERIFY_IS_FALSE(!packageDependency_FrameworkMathAdd);
     auto packageDependencyId_FrameworkMathAdd{ packageDependency_FrameworkMathAdd.Id() };

--- a/test/DynamicDependency/Test_WinRT/pch.h
+++ b/test/DynamicDependency/Test_WinRT/pch.h
@@ -27,7 +27,7 @@
 
 #include <MsixDynamicDependency.h>
 
-#include <winrt/Microsoft.ApplicationModel.DynamicDependency.h>
+#include <winrt/Microsoft.Windows.ApplicationModel.DynamicDependency.h>
 
 #include <MddBootstrap.h>
 #include <MddBootstrapTest.h>

--- a/test/DynamicDependency/data/Microsoft.ProjectReunion.Framework/appxmanifest.xml
+++ b/test/DynamicDependency/data/Microsoft.ProjectReunion.Framework/appxmanifest.xml
@@ -29,11 +29,11 @@
     <Extension Category="windows.activatableClass.inProcessServer">
       <InProcessServer>
         <Path>Microsoft.ProjectReunion.dll</Path>
-        <ActivatableClass ActivatableClassId="Microsoft.ApplicationModel.DynamicDependency.AddPackageDependencyOptions" ThreadingModel="both" />
-        <ActivatableClass ActivatableClassId="Microsoft.ApplicationModel.DynamicDependency.CreatePackageDependencyOptions" ThreadingModel="both" />
-        <ActivatableClass ActivatableClassId="Microsoft.ApplicationModel.DynamicDependency.PackageDependency" ThreadingModel="both" />
-        <ActivatableClass ActivatableClassId="Microsoft.ApplicationModel.DynamicDependency.PackageDependencyContext" ThreadingModel="both" />
-        <ActivatableClass ActivatableClassId="Microsoft.ApplicationModel.DynamicDependency.PackageDependencyRank" ThreadingModel="both" />
+        <ActivatableClass ActivatableClassId="Microsoft.Windows.ApplicationModel.DynamicDependency.AddPackageDependencyOptions" ThreadingModel="both" />
+        <ActivatableClass ActivatableClassId="Microsoft.Windows.ApplicationModel.DynamicDependency.CreatePackageDependencyOptions" ThreadingModel="both" />
+        <ActivatableClass ActivatableClassId="Microsoft.Windows.ApplicationModel.DynamicDependency.PackageDependency" ThreadingModel="both" />
+        <ActivatableClass ActivatableClassId="Microsoft.Windows.ApplicationModel.DynamicDependency.PackageDependencyContext" ThreadingModel="both" />
+        <ActivatableClass ActivatableClassId="Microsoft.Windows.ApplicationModel.DynamicDependency.PackageDependencyRank" ThreadingModel="both" />
         <ActivatableClass ActivatableClassId="Microsoft.Windows.AppLifecycle.ActivationArguments" ThreadingModel="both" />
         <ActivatableClass ActivatableClassId="Microsoft.Windows.AppLifecycle.ActivationRegistrationManager" ThreadingModel="both" />
         <ActivatableClass ActivatableClassId="Microsoft.Windows.AppLifecycle.AppInstance" ThreadingModel="both" />


### PR DESCRIPTION
Change the DynamicDependencies WinRT namespace from Microsoft.ApplicationModel.DynamicDependency to Microsoft.Windows.ApplicationModel.DynamicDependency.

This entailed changing file contents from `m.a.d` -> `m.w.a.d` and `m::a::d` -> `m::w::a::d`
and changing a few filenames from `m.a.d` -> `m.w.a.d`

Lots of DIR and grep searching to verify no stragglers left behind

Rebuilt ProjectReunion.sln - no errors

Ran DynDep tests (only code referencing DynDep WinRT API so far) - passed as expected.