### PR TITLE
DynamicDependencies bug in AppxManifest'd winrt inprocserver handling

### DIFF
--- a/dev/DynamicDependency/WinRTInprocModule.h
+++ b/dev/DynamicDependency/WinRTInprocModule.h
@@ -86,6 +86,15 @@ public:
         m_inprocServers[activatableClassId] = threadingModel;
     }
 
+    void AddInprocServers(
+        const std::unordered_map<std::wstring, MddCore::WinRT::ThreadingModel>& inprocServers)
+    {
+        for (const auto& [activatableClassId, threadingModel] : inprocServers)
+        {
+            AddInprocServer(activatableClassId, threadingModel);
+        }
+    }
+
 private:
     void Load()
     {

--- a/dev/DynamicDependency/WinRTPackage.h
+++ b/dev/DynamicDependency/WinRTPackage.h
@@ -55,6 +55,12 @@ private:
         PCWSTR elementName,
         const std::filesystem::path& filename);
 
+    void AddInprocModule(
+        MddCore::WinRTInprocModule& winrtInProcModule);
+
+    MddCore::WinRTInprocModule* FindByPath(
+        const std::wstring& path);
+
 private:
     MDD_PACKAGEDEPENDENCY_CONTEXT m_context{};
     std::wstring m_packagePath;

--- a/test/DynamicDependency/Test_WinRT/Test_WinRT.cpp
+++ b/test/DynamicDependency/Test_WinRT/Test_WinRT.cpp
@@ -10,6 +10,8 @@
 
 #include "Test_WinRT.h"
 
+#include <wil/winrt.h>
+
 namespace TF = ::Test::FileSystem;
 namespace TP = ::Test::Packages;
 
@@ -173,6 +175,48 @@ void Test::DynamicDependency::Test_WinRT::FullLifecycle_ProcessLifetime_Framewor
     VerifyPackageNotInPackageGraph(expectedPackageFullName_FrameworkMathAdd, S_OK);
     VerifyPathEnvironmentVariable(packagePath_ProjectReunionFramework, pathEnvironmentVariable.c_str());
     VerifyPackageDependency(packageDependencyId_FrameworkMathAdd, HRESULT_FROM_WIN32(ERROR_NOT_FOUND));
+}
+
+void Test::DynamicDependency::Test_WinRT::WinRT_RoGetActivationFactory_1()
+{
+    IInspectable* packageDependency{};
+    {
+        auto acid{ wil::make_unique_string < wil::unique_hstring>(L"Microsoft.Windows.ApplicationModel.DynamicDependency.PackageDependency") };
+        VERIFY_SUCCEEDED(::RoGetActivationFactory(acid.get(), IID_PPV_ARGS(&packageDependency)));
+    }
+    VERIFY_IS_NOT_NULL(packageDependency);
+
+    packageDependency->Release();
+}
+
+void Test::DynamicDependency::Test_WinRT::WinRT_RoGetActivationFactory_2()
+{
+    IInspectable* packageDependency{};
+    {
+        auto acid{ wil::make_unique_string < wil::unique_hstring>(L"Microsoft.Windows.ApplicationModel.DynamicDependency.PackageDependency") };
+        VERIFY_SUCCEEDED(::RoGetActivationFactory(acid.get(), IID_PPV_ARGS(&packageDependency)));
+    }
+    VERIFY_IS_NOT_NULL(packageDependency);
+
+    IInspectable* activationRegistrationManager{};
+    {
+        auto acid{ wil::make_unique_string < wil::unique_hstring>(L"Microsoft.Windows.AppLifecycle.ActivationRegistrationManager") };
+        VERIFY_SUCCEEDED(::RoGetActivationFactory(acid.get(), IID_PPV_ARGS(&activationRegistrationManager)));
+    }
+    VERIFY_IS_NOT_NULL(activationRegistrationManager);
+
+    activationRegistrationManager->Release();
+    packageDependency->Release();
+}
+
+void Test::DynamicDependency::Test_WinRT::WinRT_RoGetActivationFactory_NotFound()
+{
+    IInspectable* doesNotExist{};
+    {
+        auto acid{ wil::make_unique_string < wil::unique_hstring>(L"Does.Not.Exist") };
+        VERIFY_ARE_EQUAL(REGDB_E_CLASSNOTREG, ::RoGetActivationFactory(acid.get(), IID_PPV_ARGS(&doesNotExist)));
+    }
+    VERIFY_IS_NULL(doesNotExist);
 }
 
 void Test::DynamicDependency::Test_WinRT::VerifyPackageDependency(

--- a/test/DynamicDependency/Test_WinRT/Test_WinRT.h
+++ b/test/DynamicDependency/Test_WinRT/Test_WinRT.h
@@ -38,6 +38,10 @@ namespace Test::DynamicDependency
         TEST_METHOD(Create_Add_Architectures_Explicit);
         TEST_METHOD(Create_Add_Architectures_Current);
 
+        TEST_METHOD(WinRT_RoGetActivationFactory_1);
+        TEST_METHOD(WinRT_RoGetActivationFactory_2);
+        TEST_METHOD(WinRT_RoGetActivationFactory_NotFound);
+
     private:
         static void VerifyPackageDependency(
             PCWSTR packageDependencyId,

--- a/test/DynamicDependency/data/Microsoft.ProjectReunion.Framework/appxmanifest.xml
+++ b/test/DynamicDependency/data/Microsoft.ProjectReunion.Framework/appxmanifest.xml
@@ -26,6 +26,14 @@
   </Resources>
 
   <Extensions>
+    <!-- Declare multiple InProcessServer extensions to ensure tests cover all possible declarations:
+           * InProcessServer extensions in a manifest
+           * 2+ InProcessServer extensions in a manifest
+           * 2+ InProcessServer extensions with the same <Path>
+         Schema validation ensures you can't make a package with 2+ ActivatableClass entries
+         in the same manifest with the same ActivatableClassId (regardless in same
+         or different <Extension>s).
+      -->
     <Extension Category="windows.activatableClass.inProcessServer">
       <InProcessServer>
         <Path>Microsoft.ProjectReunion.dll</Path>
@@ -34,6 +42,11 @@
         <ActivatableClass ActivatableClassId="Microsoft.Windows.ApplicationModel.DynamicDependency.PackageDependency" ThreadingModel="both" />
         <ActivatableClass ActivatableClassId="Microsoft.Windows.ApplicationModel.DynamicDependency.PackageDependencyContext" ThreadingModel="both" />
         <ActivatableClass ActivatableClassId="Microsoft.Windows.ApplicationModel.DynamicDependency.PackageDependencyRank" ThreadingModel="both" />
+      </InProcessServer>
+    </Extension>
+    <Extension Category="windows.activatableClass.inProcessServer">
+      <InProcessServer>
+        <Path>Microsoft.ProjectReunion.dll</Path>
         <ActivatableClass ActivatableClassId="Microsoft.Windows.AppLifecycle.ActivationArguments" ThreadingModel="both" />
         <ActivatableClass ActivatableClassId="Microsoft.Windows.AppLifecycle.ActivationRegistrationManager" ThreadingModel="both" />
         <ActivatableClass ActivatableClassId="Microsoft.Windows.AppLifecycle.AppInstance" ThreadingModel="both" />


### PR DESCRIPTION
2 bugs in AppxManifest-based UndockedRegFreeWinRT support we unnoticed due to a gap in test coverage

* 2+ `<Extension Category='windows.activatableClass.inProcessServer'>` in a manifest
* 2+ inprocservers with the same Path

Code updated to handle these cases as expected.

The PRfwk test package (`test\DynamicDependency\data\Microsoft.ProjectReunion.Framework`) was updated to ensure coverage of these scenarios

Added new WinRT_RoGetActivationFactory_* test cases to verify the fix. Tests pass now as expected