### PR TITLE
Copy Microsoft.ProjectReunion.Bootstrap.dll to $(OutDir) for non-native projects.

### DIFF
--- a/build/AzurePipelinesTemplates/ProjectReunion-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/ProjectReunion-CreateNugetPackage-Job.yml
@@ -56,6 +56,7 @@ jobs:
         Copy-Item -Path "$targetsFilePath\ProjectReunion-Nuget-Native.WinRt.props" -Destination "$fullpackagePath\build\native\ProjectReunion-Nuget-Native.WinRt.props"
         Copy-Item -Path "$targetsFilePath\Microsoft.ProjectReunion.Foundation.targets" -Destination "$fullpackagePath\build\Microsoft.ProjectReunion.Foundation.targets"
         Copy-Item -Path "$targetsFilePath\Microsoft.ProjectReunion.Foundation.props" -Destination "$fullpackagePath\build\Microsoft.ProjectReunion.Foundation.props"
+        Copy-Item -Path "$targetsFilePath\Microsoft.ProjectReunion.Bootstrap.targets" -Destination "$fullpackagePath\build\Microsoft.ProjectReunion.Bootstrap.targets"
 
         Copy-Item -Path "$targetsFilePath\AppxManifest.xml" -Destination "$fullpackagePath\AppxManifest.xml"
 

--- a/build/NuSpecs/Microsoft.ProjectReunion.Bootstrap.targets
+++ b/build/NuSpecs/Microsoft.ProjectReunion.Bootstrap.targets
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <_ProjectReunionFoundationPlatform Condition="'$(Platform)' == 'Win32'">x86</_ProjectReunionFoundationPlatform>
+    <_ProjectReunionFoundationPlatform Condition="'$(Platform)' != 'Win32'">$(Platform)</_ProjectReunionFoundationPlatform>
+  </PropertyGroup>
+
+  <Target Name="BinPlaceBootstrapDll" Condition="'$(AppxPackage)' != 'true'" AfterTargets="Build">
+    <Copy SourceFiles="$(MSBuildThisFileDirectory)..\runtimes\lib\native\$(_ProjectReunionFoundationPlatform)\Microsoft.ProjectReunion.Bootstrap.dll" DestinationFolder="$(OutDir)" OverwriteReadOnlyFiles="true" ContinueOnError="false"/>
+  </Target>
+
+</Project>

--- a/build/NuSpecs/Microsoft.ProjectReunion.Foundation.targets
+++ b/build/NuSpecs/Microsoft.ProjectReunion.Foundation.targets
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.ApplicationModel.Resources.targets" />
-  <Import Project="$(MSBuildThisFileDirectory)Microsoft.ProjectReunion.Bootstrap.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.ProjectReunion.Bootstrap.targets" Condition="'$(MSBuildProjectExtension)' != '.wapproj'" />
 
   <ItemGroup>
     <ProjectCapability Include="ProjectReunion" />

--- a/build/NuSpecs/Microsoft.ProjectReunion.Foundation.targets
+++ b/build/NuSpecs/Microsoft.ProjectReunion.Foundation.targets
@@ -2,7 +2,8 @@
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.ApplicationModel.Resources.targets" />
-  
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.ProjectReunion.Bootstrap.targets" />
+
   <ItemGroup>
     <ProjectCapability Include="ProjectReunion" />
   </ItemGroup>


### PR DESCRIPTION
This file was not being bin placed but needs to be.

**How verified**
Used a test app.