### PR TITLE
Reduce MRM.dll binary size by 37 KB by disabling RTTI.

### DIFF
--- a/dev/MRTCore/mrt/Core/src/MRM.vcxproj
+++ b/dev/MRTCore/mrt/Core/src/MRM.vcxproj
@@ -77,18 +77,25 @@
   <PropertyGroup Condition="'$(Platform)'=='ARM64'">
     <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>
   </PropertyGroup>
+  <!-- Shared settings for all Configurations and Platforms -->
   <ItemDefinitionGroup>
     <ClCompile>
       <PreprocessorDefinitions>WIN32;_WINDOWS;_USRDLL;STANDALONEDLL_EXPORTS;UNICODE;_UNICODE;DOWNLEVEL_PRIOR_TO_WIN8;WIL_SUPPRESS_PRIVATE_API_USE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level4</WarningLevel>
       <TreatWarningAsError>true</TreatWarningAsError>
       <AdditionalIncludeDirectories>..\..\mrm\include</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
+      <!-- MRT Core doesn't use RTTI. -->
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
     </ClCompile>
     <Link>
       <AdditionalDependencies>$(OutDir)..\mrmmin\mrmmin.lib;rpcrt4.lib;onecoreuap.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>MRM.def</ModuleDefinitionFile>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
@@ -137,32 +144,10 @@
       <!-- EnableCOMDATFolding and OptimizeReferences are set to true below for all build configurations. -->
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup>
-    <Link>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-    </Link>
-    <ClCompile>
-      <LanguageStandard>stdcpp17</LanguageStandard>
-      <ControlFlowGuard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">Guard</ControlFlowGuard>
-      <ControlFlowGuard Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">Guard</ControlFlowGuard>
-      <ControlFlowGuard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">Guard</ControlFlowGuard>
-      <ControlFlowGuard Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">Guard</ControlFlowGuard>
-      <ControlFlowGuard Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Guard</ControlFlowGuard>
-      <ControlFlowGuard Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Guard</ControlFlowGuard>
-      <RuntimeTypeInfo>false</RuntimeTypeInfo>
-    </ClCompile>
-  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Platform)'=='Win32'">
     <Link>
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
-    <ClCompile>
-      <ControlFlowGuard Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Guard</ControlFlowGuard>
-    </ClCompile>
-    <ClCompile>
-      <ControlFlowGuard Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Guard</ControlFlowGuard>
-    </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="MRM.cpp" />

--- a/dev/MRTCore/mrt/Core/src/MRM.vcxproj
+++ b/dev/MRTCore/mrt/Core/src/MRM.vcxproj
@@ -150,6 +150,7 @@
       <ControlFlowGuard Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">Guard</ControlFlowGuard>
       <ControlFlowGuard Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Guard</ControlFlowGuard>
       <ControlFlowGuard Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Guard</ControlFlowGuard>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Platform)'=='Win32'">

--- a/dev/MRTCore/mrt/mrm/mrmex/mrmex.vcxproj
+++ b/dev/MRTCore/mrt/mrm/mrmex/mrmex.vcxproj
@@ -111,6 +111,13 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <!-- Shared settings for all Configurations and Platforms -->
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <!-- MRT Core doesn't use RTTI. -->
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+    </ClCompile>
+  </ItemDefinitionGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>

--- a/dev/MRTCore/mrt/mrm/mrmmin/mrmmin.vcxproj
+++ b/dev/MRTCore/mrt/mrm/mrmmin/mrmmin.vcxproj
@@ -246,6 +246,7 @@
     <ClCompile>
       <AdditionalIncludeDirectories>..\include</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">

--- a/dev/MRTCore/mrt/mrm/mrmmin/mrmmin.vcxproj
+++ b/dev/MRTCore/mrt/mrm/mrmmin/mrmmin.vcxproj
@@ -112,6 +112,13 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <!-- Shared settings for all Configurations and Platforms -->
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <!-- MRT Core doesn't use RTTI. -->
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+    </ClCompile>
+  </ItemDefinitionGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
@@ -246,7 +253,6 @@
     <ClCompile>
       <AdditionalIncludeDirectories>..\include</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
-      <RuntimeTypeInfo>false</RuntimeTypeInfo>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">


### PR DESCRIPTION
MRT Core doesn't use RTTI, but the `*.vcxproj` files that are used to build `MRM.dll` have this enabled (it is implicitly set by default).

This change disables RTTI for `MRM.dll` which reduces the overall binary file size (for x64 Release) by **37 KB**.


| File    | Size Before     | Size After     |
|---------|----------------:|---------------:|
| MRM.dll | 348,672 | 310,784 |

**Delta** = **37,888 bytes (37 KB)**


SizeBench delta for MRM.dll

| Name    | Size on disk Diff | Size in memory Diff | Size in memory (including section padding) Diff |
| ------- | ----------------- | ------------------- | ----------------------------------------------- |
| \_RDATA | 0                 | 0                   | 0                                               |
| .rsrc   | 0                 | 0                   | 0                                               |
| .pdata  | -1024             | -624                | 0                                               |
| .reloc  | -1024             | -624                | 0                                               |
| .text   | -5632             | -5424               | -4096                                           |
| .data   | -10240            | -10080              | -12288                                          |
| .rdata  | -19968            | -19888              | -20480                                          |

This change also cleans up some of the duplicated/redundant vcxproj values as well.
