### PR TITLE
Amending PowerMode Functions

### DIFF
--- a/dev/PowerNotifications/ClosedSourceMock.cpp
+++ b/dev/PowerNotifications/ClosedSourceMock.cpp
@@ -242,30 +242,3 @@ HRESULT UnregisterUserPresenceStatusChangedListener(UserPresenceStatusRegistrati
     onUserPresenceStatusChanged_callbacks.erase(reinterpret_cast<index>(registration));
     return S_OK;
 }
-
-HRESULT GetSystemAwayModeStatus(DWORD* systemAwayModeStatusOut)
-{
-    *systemAwayModeStatusOut = static_cast<DWORD>(winrt::Microsoft::ProjectReunion::SystemAwayModeStatus::Entering);
-    return S_OK;
-}
-
-HRESULT RegisterSystemAwayModeStatusChangedListener(OnSystemAwayModeStatusChanged listener, SystemAwayModeStatusRegistration* registration)
-{
-    *registration = reinterpret_cast<SystemAwayModeStatusRegistration>(g_idx++);
-    onSystemAwayModeStatusChanged_callbacks[g_idx] = listener;
-    std::thread thread([]() {
-        std::this_thread::sleep_for(std::chrono::milliseconds(50));
-        for (const auto& [key, callbackFn] : onSystemAwayModeStatusChanged_callbacks)
-        {
-            callbackFn(static_cast<DWORD>(winrt::Microsoft::ProjectReunion::SystemAwayModeStatus::Exiting));
-        }
-        });
-    thread.detach();
-    return S_OK;
-}
-
-HRESULT UnregisterSystemAwayModeStatusChangedListener(SystemAwayModeStatusRegistration registration)
-{
-    onSystemAwayModeStatusChanged_callbacks.erase(reinterpret_cast<index>(registration));
-    return S_OK;
-}

--- a/dev/PowerNotifications/PowerNotifications.cpp
+++ b/dev/PowerNotifications/PowerNotifications.cpp
@@ -199,7 +199,7 @@ namespace winrt::Microsoft::ProjectReunion::implementation
             make_self<factory_implementation::PowerManager>()->m_systemIdleStatusHandle));
     }
 
-    bool IsV2Supported()
+    bool IsEffectivePowerModeV2Supported()
     {
         // We check for the version supported by checking if the feature is supported
         // Using NULL as an indicator for uninitialized cache value
@@ -207,10 +207,7 @@ namespace winrt::Microsoft::ProjectReunion::implementation
         {
             PVOID handle;
             auto hr = PowerRegisterForEffectivePowerModeNotifications(
-                EFFECTIVE_POWER_MODE_V2, [](EFFECTIVE_POWER_MODE, PVOID)
-                {
-                    // Set a cached value?
-                }, NULL, &handle);
+                EFFECTIVE_POWER_MODE_V2, [](EFFECTIVE_POWER_MODE, PVOID) {}, NULL, &handle);
             g_powerModeVersion = hr == S_OK ? EFFECTIVE_POWER_MODE_V2 : EFFECTIVE_POWER_MODE_V1;
             check_hresult(PowerUnregisterFromEffectivePowerModeNotifications(handle));
         }
@@ -224,7 +221,7 @@ namespace winrt::Microsoft::ProjectReunion::implementation
 
     void EffectivePowerMode_Register()
     {
-        ULONG version = IsV2Supported() ? EFFECTIVE_POWER_MODE_V2 : EFFECTIVE_POWER_MODE_V1;
+        ULONG version = IsEffectivePowerModeV2Supported() ? EFFECTIVE_POWER_MODE_V2 : EFFECTIVE_POWER_MODE_V1;
         check_hresult(PowerRegisterForEffectivePowerModeNotifications(
             version, [](EFFECTIVE_POWER_MODE mode, PVOID)
             {
@@ -245,7 +242,7 @@ namespace winrt::Microsoft::ProjectReunion::implementation
         static std::promise<EFFECTIVE_POWER_MODE> promiseObj;
         static std::future<EFFECTIVE_POWER_MODE> futureObj;
         PVOID handle;
-        ULONG version = IsV2Supported() ? EFFECTIVE_POWER_MODE_V2 : EFFECTIVE_POWER_MODE_V1;
+        ULONG version = IsEffectivePowerModeV2Supported() ? EFFECTIVE_POWER_MODE_V2 : EFFECTIVE_POWER_MODE_V1;
         promiseObj = std::promise<EFFECTIVE_POWER_MODE>();
         futureObj = promiseObj.get_future();
 

--- a/dev/PowerNotifications/PowerNotifications.cpp
+++ b/dev/PowerNotifications/PowerNotifications.cpp
@@ -198,29 +198,58 @@ namespace winrt::Microsoft::ProjectReunion::implementation
             make_self<factory_implementation::PowerManager>()->m_systemIdleStatusHandle));
     }
 
-    // PowerSchemePersonality Functions
-    EventType& PowerSchemePersonality_Event()
+    // PowerSchemePersonality V1 Functions
+    EventType& PowerSchemePersonalityV1_Event()
     {
-        return make_self<factory_implementation::PowerManager>()->m_powerSchemePersonalityChangedEvent;
+        return make_self<factory_implementation::PowerManager>()->m_powerSchemePersonalityV1ChangedEvent;
     }
 
-    void PowerSchemePersonality_Register()
+    void PowerSchemePersonalityV1_Register()
     {
-        //check_hresult(PowerNotifications_RegisterPowerSchemePersonalityChangedListener(
-        //    &PowerManager::PowerSchemePersonalityChanged_Callback,
-        //    &make_self<factory_implementation::PowerManager>()->m_powerSchemePersonalityHandle));
+        check_hresult(PowerNotifications_RegisterPowerSchemePersonalityChangedListener(
+            EFFECTIVE_POWER_MODE_V1,
+            &PowerManager::PowerSchemePersonalityV1Changed_Callback,
+            &make_self<factory_implementation::PowerManager>()->m_powerSchemePersonalityV1Handle));
     }
 
-    void PowerSchemePersonality_Unregister()
+    void PowerSchemePersonalityV1_Unregister()
     {
-        //check_hresult(PowerNotifications_UnregisterPowerSchemePersonalityChangedListener(
-        //    make_self<factory_implementation::PowerManager>()->m_powerSchemePersonalityHandle));
+        check_hresult(PowerNotifications_UnregisterPowerSchemePersonalityChangedListener(
+            make_self<factory_implementation::PowerManager>()->m_powerSchemePersonalityV1Handle));
     }
 
-    void PowerSchemePersonality_Update()
+    void PowerSchemePersonalityV1_Update()
     {
-        //check_hresult(PowerNotifications_GetPowerSchemePersonality(
-        //    &make_self<factory_implementation::PowerManager>()->m_cachedPowerSchemePersonality));
+        check_hresult(PowerNotifications_GetPowerSchemePersonality(
+            EFFECTIVE_POWER_MODE_V1,
+            &make_self<factory_implementation::PowerManager>()->m_cachedPowerSchemePersonalityV1));
+    }
+
+    // PowerSchemePersonality V2 Functions
+    EventType& PowerSchemePersonalityV2_Event()
+    {
+        return make_self<factory_implementation::PowerManager>()->m_powerSchemePersonalityv2ChangedEvent;
+    }
+
+    void PowerSchemePersonalityV2_Register()
+    {
+        check_hresult(PowerNotifications_RegisterPowerSchemePersonalityChangedListener(
+            EFFECTIVE_POWER_MODE_V2,
+            &PowerManager::PowerSchemePersonalityV2Changed_Callback,
+            &make_self<factory_implementation::PowerManager>()->m_powerSchemePersonalityV2Handle));
+    }
+
+    void PowerSchemePersonalityV2_Unregister()
+    {
+        check_hresult(PowerNotifications_UnregisterPowerSchemePersonalityChangedListener(
+            make_self<factory_implementation::PowerManager>()->m_powerSchemePersonalityV2Handle));
+    }
+
+    void PowerSchemePersonalityV2_Update()
+    {
+        check_hresult(PowerNotifications_GetPowerSchemePersonality(
+            EFFECTIVE_POWER_MODE_V2,
+            &make_self<factory_implementation::PowerManager>()->m_cachedPowerSchemePersonalityV2));
     }
 
     // UserPresenceStatus Functions

--- a/dev/PowerNotifications/PowerNotifications.cpp
+++ b/dev/PowerNotifications/PowerNotifications.cpp
@@ -239,21 +239,23 @@ namespace winrt::Microsoft::ProjectReunion::implementation
     {
         // Effectively the Get() for PowerMode
         // Needs to get a temporary subscription to get most recent value
-        // Also, we need a static so that it can be accessed in the lambda below
-        // since references or [&] doesn't work
-        static std::promise<EFFECTIVE_POWER_MODE> promiseObj;
-        static std::future<EFFECTIVE_POWER_MODE> futureObj;
+
+        struct notify_callback {
+            EFFECTIVE_POWER_MODE mode;
+            wil::slim_event done;
+        } context;
+
         PVOID handle;
         ULONG version = GetEffectivePowerModeVersion();
-        promiseObj = std::promise<EFFECTIVE_POWER_MODE>();
-        futureObj = promiseObj.get_future();
+        auto handler = [](EFFECTIVE_POWER_MODE mode, PVOID rawContext) {
+            auto context = reinterpret_cast<notify_callback*>(rawContext);
+            context->mode = mode;
+            context->done.SetEvent();
+        };
 
-        check_hresult(PowerRegisterForEffectivePowerModeNotifications(
-            version, [](EFFECTIVE_POWER_MODE mode, PVOID)
-            {
-                promiseObj.set_value(mode);
-            }, NULL, &handle));
-        make_self<factory_implementation::PowerManager>()->m_cachedPowerMode = futureObj.get();
+        check_hresult(PowerRegisterForEffectivePowerModeNotifications(version, handler, &context, &handle));
+        context.done.wait();
+        make_self<factory_implementation::PowerManager>()->m_cachedPowerMode = context.mode;
         check_hresult(PowerUnregisterFromEffectivePowerModeNotifications(handle));
     }
 

--- a/dev/PowerNotifications/PowerNotifications.cpp
+++ b/dev/PowerNotifications/PowerNotifications.cpp
@@ -199,7 +199,7 @@ namespace winrt::Microsoft::ProjectReunion::implementation
             make_self<factory_implementation::PowerManager>()->m_systemIdleStatusHandle));
     }
 
-    bool IsEffectivePowerModeV2Supported()
+    ULONG GetEffectivePowerModeVersion()
     {
         // We check for the version supported by checking if the feature is supported
         // Using NULL as an indicator for uninitialized cache value
@@ -211,7 +211,7 @@ namespace winrt::Microsoft::ProjectReunion::implementation
             g_powerModeVersion = hr == S_OK ? EFFECTIVE_POWER_MODE_V2 : EFFECTIVE_POWER_MODE_V1;
             check_hresult(PowerUnregisterFromEffectivePowerModeNotifications(handle));
         }
-        return g_powerModeVersion == EFFECTIVE_POWER_MODE_V2;
+        return g_powerModeVersion;
     }
 
     EventType& EffectivePowerMode_Event()
@@ -221,7 +221,7 @@ namespace winrt::Microsoft::ProjectReunion::implementation
 
     void EffectivePowerMode_Register()
     {
-        ULONG version = IsEffectivePowerModeV2Supported() ? EFFECTIVE_POWER_MODE_V2 : EFFECTIVE_POWER_MODE_V1;
+        ULONG version = GetEffectivePowerModeVersion();
         check_hresult(PowerRegisterForEffectivePowerModeNotifications(
             version, [](EFFECTIVE_POWER_MODE mode, PVOID)
             {
@@ -239,10 +239,12 @@ namespace winrt::Microsoft::ProjectReunion::implementation
     {
         // Effectively the Get() for PowerMode
         // Needs to get a temporary subscription to get most recent value
+        // Also, we need a static so that it can be accessed in the lambda below
+        // since references or [&] doesn't work
         static std::promise<EFFECTIVE_POWER_MODE> promiseObj;
         static std::future<EFFECTIVE_POWER_MODE> futureObj;
         PVOID handle;
-        ULONG version = IsEffectivePowerModeV2Supported() ? EFFECTIVE_POWER_MODE_V2 : EFFECTIVE_POWER_MODE_V1;
+        ULONG version = GetEffectivePowerModeVersion();
         promiseObj = std::promise<EFFECTIVE_POWER_MODE>();
         futureObj = promiseObj.get_future();
 
@@ -251,8 +253,7 @@ namespace winrt::Microsoft::ProjectReunion::implementation
             {
                 promiseObj.set_value(mode);
             }, NULL, &handle));
-        auto& mode = make_self<factory_implementation::PowerManager>()->m_cachedPowerMode;
-        mode = futureObj.get();
+        make_self<factory_implementation::PowerManager>()->m_cachedPowerMode = futureObj.get();
         check_hresult(PowerUnregisterFromEffectivePowerModeNotifications(handle));
     }
 

--- a/dev/PowerNotifications/PowerNotifications.cpp
+++ b/dev/PowerNotifications/PowerNotifications.cpp
@@ -61,7 +61,7 @@ namespace winrt::Microsoft::ProjectReunion::implementation
         make_self<factory_implementation::PowerManager>()->ProcessCompositeBatteryStatus(
             make_self<factory_implementation::PowerManager>()->m_cachedCompositeBatteryStatus);
     }
-   
+
     // PowerSupplyStatus Functions
     EventType& PowerSupplyStatus_Event()
     {
@@ -82,7 +82,7 @@ namespace winrt::Microsoft::ProjectReunion::implementation
     {
         BatteryStatus_Update();
     }
-   
+
     // RemainingChargePercent Functions
     EventType& RemainingChargePercent_Event()
     {
@@ -128,7 +128,7 @@ namespace winrt::Microsoft::ProjectReunion::implementation
         check_hresult(GetDischargeTime(
             &make_self<factory_implementation::PowerManager>()->m_cachedDischargeTime));
     }
-   
+
     // PowerSourceStatus Functions
     EventType& PowerSourceStatus_Event()
     {
@@ -153,7 +153,7 @@ namespace winrt::Microsoft::ProjectReunion::implementation
         check_hresult(GetPowerCondition(
             &make_self<factory_implementation::PowerManager>()->m_cachedPowerSourceStatus));
     }
-   
+
     // DisplayStatus Functions
     EventType& DisplayStatus_Event()
     {
@@ -178,7 +178,7 @@ namespace winrt::Microsoft::ProjectReunion::implementation
         check_hresult(GetDisplayStatus(
             &make_self<factory_implementation::PowerManager>()->m_cachedDisplayStatus));
     }
-   
+
     // SystemIdleStatus Functions
     EventType& SystemIdleStatus_Event()
     {
@@ -197,7 +197,7 @@ namespace winrt::Microsoft::ProjectReunion::implementation
         check_hresult(UnregisterSystemIdleStatusChangedListener(
             make_self<factory_implementation::PowerManager>()->m_systemIdleStatusHandle));
     }
-   
+
     // PowerSchemePersonality Functions
     EventType& PowerSchemePersonality_Event()
     {
@@ -206,23 +206,23 @@ namespace winrt::Microsoft::ProjectReunion::implementation
 
     void PowerSchemePersonality_Register()
     {
-        check_hresult(RegisterPowerSchemePersonalityChangedListener(
-            &PowerManager::PowerSchemePersonalityChanged_Callback,
-            &make_self<factory_implementation::PowerManager>()->m_powerSchemePersonalityHandle));
+        //check_hresult(PowerNotifications_RegisterPowerSchemePersonalityChangedListener(
+        //    &PowerManager::PowerSchemePersonalityChanged_Callback,
+        //    &make_self<factory_implementation::PowerManager>()->m_powerSchemePersonalityHandle));
     }
 
     void PowerSchemePersonality_Unregister()
     {
-        check_hresult(UnregisterPowerSchemePersonalityChangedListener(
-            make_self<factory_implementation::PowerManager>()->m_powerSchemePersonalityHandle));
+        //check_hresult(PowerNotifications_UnregisterPowerSchemePersonalityChangedListener(
+        //    make_self<factory_implementation::PowerManager>()->m_powerSchemePersonalityHandle));
     }
 
     void PowerSchemePersonality_Update()
     {
-        check_hresult(GetPowerSchemePersonality(
-            &make_self<factory_implementation::PowerManager>()->m_cachedPowerSchemePersonality));
+        //check_hresult(PowerNotifications_GetPowerSchemePersonality(
+        //    &make_self<factory_implementation::PowerManager>()->m_cachedPowerSchemePersonality));
     }
-   
+
     // UserPresenceStatus Functions
     EventType& UserPresenceStatus_Event()
     {
@@ -246,31 +246,6 @@ namespace winrt::Microsoft::ProjectReunion::implementation
     {
         check_hresult(GetUserPresenceStatus(
             &make_self<factory_implementation::PowerManager>()->m_cachedUserPresenceStatus));
-    }
-
-    // SystemAwayModeStatus Functions
-    EventType& SystemAwayModeStatus_Event()
-    {
-        return make_self<factory_implementation::PowerManager>()->m_systemAwayModeStatusChangedEvent;
-    }
-
-    void SystemAwayModeStatus_Register()
-    {
-        check_hresult(RegisterSystemAwayModeStatusChangedListener(
-            &PowerManager::SystemAwayModeStatusChanged_Callback,
-            &make_self<factory_implementation::PowerManager>()->m_systemAwayModeStatusHandle));
-    }
-
-    void SystemAwayModeStatus_Unregister()
-    {
-        check_hresult(UnregisterSystemAwayModeStatusChangedListener(
-            make_self<factory_implementation::PowerManager>()->m_systemAwayModeStatusHandle));
-    }
-
-    void SystemAwayModeStatus_Update()
-    {
-        check_hresult(GetSystemAwayModeStatus(
-            &make_self<factory_implementation::PowerManager>()->m_cachedSystemAwayModeStatus));
     }
 
     // SystemSuspendStatus Functions
@@ -301,5 +276,4 @@ namespace winrt::Microsoft::ProjectReunion::implementation
         check_win32(PowerUnregisterSuspendResumeNotification(
             make_self<factory_implementation::PowerManager>()->m_systemSuspendHandle));
     }
-
 }

--- a/dev/PowerNotifications/PowerNotifications.h
+++ b/dev/PowerNotifications/PowerNotifications.h
@@ -57,15 +57,10 @@ namespace winrt::Microsoft::ProjectReunion::implementation
     void SystemIdleStatus_Register();
     void SystemIdleStatus_Unregister();
 
-    EventType& PowerSchemePersonalityV1_Event();
-    void PowerSchemePersonalityV1_Register();
-    void PowerSchemePersonalityV1_Unregister();
-    void PowerSchemePersonalityV1_Update();
-
-    EventType& PowerSchemePersonalityV2_Event();
-    void PowerSchemePersonalityV2_Register();
-    void PowerSchemePersonalityV2_Unregister();
-    void PowerSchemePersonalityV2_Update();
+    EventType& EffectivePowerMode_Event();
+    void EffectivePowerMode_Register();
+    void EffectivePowerMode_Unregister();
+    void EffectivePowerMode_Update();
 
     EventType& UserPresenceStatus_Event();
     void UserPresenceStatus_Register();
@@ -106,8 +101,7 @@ namespace winrt::Microsoft::ProjectReunion::factory_implementation
         DWORD m_cachedUserPresenceStatus;
         DWORD m_cachedSystemAwayModeStatus;
         DWORD m_cachedPowerSourceStatus;
-        EFFECTIVE_POWER_MODE m_cachedPowerSchemePersonalityV1;
-        EFFECTIVE_POWER_MODE m_cachedPowerSchemePersonalityV2;
+        EFFECTIVE_POWER_MODE m_cachedPowerMode;
         ULONGLONG m_cachedDischargeTime;
         winrt::Microsoft::ProjectReunion::SystemSuspendStatus m_systemSuspendStatus;
         ::EnergySaverStatus m_cachedEnergySaverStatus;
@@ -125,8 +119,7 @@ namespace winrt::Microsoft::ProjectReunion::factory_implementation
         EventType m_powerSourceStatusChangedEvent;
         EventType m_displayStatusChangedEvent;
         EventType m_systemIdleStatusChangedEvent;
-        EventType m_powerSchemePersonalityV1ChangedEvent;
-        EventType m_powerSchemePersonalityv2ChangedEvent;
+        EventType m_powerModeChangedEvent;
         EventType m_userPresenceStatusChangedEvent;
         EventType m_systemAwayModeStatusChangedEvent;
         EventType m_systemSuspendStatusChangedEvent;
@@ -137,8 +130,7 @@ namespace winrt::Microsoft::ProjectReunion::factory_implementation
         DischargeTimeRegistration m_dischargeTimeHandle;
         DisplayStatusRegistration m_displayStatusHandle;
         SystemIdleStatusRegistration m_systemIdleStatusHandle;
-        PowerSchemePersonalityRegistration m_powerSchemePersonalityV1Handle;
-        PowerSchemePersonalityRegistration m_powerSchemePersonalityV2Handle;
+        PVOID m_powerModeHandle;
         UserPresenceStatusRegistration m_userPresenceStatusHandle;
         HPOWERNOTIFY m_systemSuspendHandle;
 
@@ -190,17 +182,11 @@ namespace winrt::Microsoft::ProjectReunion::factory_implementation
             &winrt::Microsoft::ProjectReunion::implementation::SystemIdleStatus_Unregister,
             &winrt::Microsoft::ProjectReunion::implementation::NoOperation };
 
-        PowerFunctionDetails powerSchemePersonalityV1Func{
-            &winrt::Microsoft::ProjectReunion::implementation::PowerSchemePersonalityV1_Event,
-            &winrt::Microsoft::ProjectReunion::implementation::PowerSchemePersonalityV1_Register,
-            &winrt::Microsoft::ProjectReunion::implementation::PowerSchemePersonalityV1_Unregister,
-            &winrt::Microsoft::ProjectReunion::implementation::PowerSchemePersonalityV1_Update };
-
-        PowerFunctionDetails powerSchemePersonalityV2Func{
-            &winrt::Microsoft::ProjectReunion::implementation::PowerSchemePersonalityV2_Event,
-            &winrt::Microsoft::ProjectReunion::implementation::PowerSchemePersonalityV2_Register,
-            &winrt::Microsoft::ProjectReunion::implementation::PowerSchemePersonalityV2_Unregister,
-            &winrt::Microsoft::ProjectReunion::implementation::PowerSchemePersonalityV2_Update };
+        PowerFunctionDetails EffectivePowerModeFunc{
+            &winrt::Microsoft::ProjectReunion::implementation::EffectivePowerMode_Event,
+            &winrt::Microsoft::ProjectReunion::implementation::EffectivePowerMode_Register,
+            &winrt::Microsoft::ProjectReunion::implementation::EffectivePowerMode_Unregister,
+            &winrt::Microsoft::ProjectReunion::implementation::EffectivePowerMode_Update };
 
         PowerFunctionDetails userPresenceStatusFunc{
             &winrt::Microsoft::ProjectReunion::implementation::UserPresenceStatus_Event,
@@ -528,53 +514,28 @@ namespace winrt::Microsoft::ProjectReunion::factory_implementation
             RaiseEvent(systemIdleStatusFunc);
         }
 
-
-        // PowerSchemePersonality v1 Functions
-        winrt::Microsoft::ProjectReunion::PowerSchemePersonalityV1 PowerSchemePersonalityV1()
+        // EffectivePowerMode Functions
+        winrt::Microsoft::ProjectReunion::EffectivePowerMode EffectivePowerMode()
         {
-            CheckRegistrationAndOrUpdateValue(powerSchemePersonalityV1Func);
-            return static_cast<winrt::Microsoft::ProjectReunion::PowerSchemePersonalityV1>(m_cachedPowerSchemePersonalityV1);
+            CheckRegistrationAndOrUpdateValue(EffectivePowerModeFunc);
+            return static_cast<winrt::Microsoft::ProjectReunion::EffectivePowerMode>(m_cachedPowerMode);
         }
 
-        event_token PowerSchemePersonalityV1Changed(const PowerEventHandle& handler)
+        event_token EffectivePowerModeChanged(const PowerEventHandle& handler)
         {
-            return AddCallback(powerSchemePersonalityV1Func, handler);
+            return AddCallback(EffectivePowerModeFunc, handler);
         }
 
-        void PowerSchemePersonalityV1Changed(const event_token& token)
+        void EffectivePowerModeChanged(const event_token& token)
         {
-            RemoveCallback(powerSchemePersonalityV1Func, token);
+            RemoveCallback(EffectivePowerModeFunc, token);
         }
 
-        void PowerSchemePersonalityV1Changed_Callback(EFFECTIVE_POWER_MODE mode)
+        void EffectivePowerModeChanged_Callback(EFFECTIVE_POWER_MODE mode)
         {
-            m_cachedPowerSchemePersonalityV1 = mode;
-            RaiseEvent(powerSchemePersonalityV1Func);
+            m_cachedPowerMode = mode;
+            RaiseEvent(EffectivePowerModeFunc);
         }
-
-        // PowerSchemePersonality v2 Functions
-        winrt::Microsoft::ProjectReunion::PowerSchemePersonalityV2 PowerSchemePersonalityV2()
-        {
-            CheckRegistrationAndOrUpdateValue(powerSchemePersonalityV2Func);
-            return static_cast<winrt::Microsoft::ProjectReunion::PowerSchemePersonalityV2>(m_cachedPowerSchemePersonalityV2);
-        }
-
-        event_token PowerSchemePersonalityV2Changed(const PowerEventHandle& handler)
-        {
-            return AddCallback(powerSchemePersonalityV2Func, handler);
-        }
-
-        void PowerSchemePersonalityV2Changed(const event_token& token)
-        {
-            RemoveCallback(powerSchemePersonalityV2Func, token);
-        }
-
-        void PowerSchemePersonalityV2Changed_Callback(EFFECTIVE_POWER_MODE mode)
-        {
-            m_cachedPowerSchemePersonalityV2 = mode;
-            RaiseEvent(powerSchemePersonalityV2Func);
-        }
-
 
         // UserPresenceStatus Functions
         winrt::Microsoft::ProjectReunion::UserPresenceStatus UserPresenceStatus()
@@ -647,9 +608,12 @@ namespace winrt::Microsoft::ProjectReunion::factory_implementation
 
 namespace winrt::Microsoft::ProjectReunion::implementation
 {
+    // EffectivePowerMode variables
+    static ULONG g_powerModeVersion = NULL;
+    static PVOID g_powerModeHandle;
 
-     struct PowerManager
-     {
+    struct PowerManager
+    {
         PowerManager() = default;
 
         //Get function forwards
@@ -693,14 +657,9 @@ namespace winrt::Microsoft::ProjectReunion::implementation
             return make_self<factory_implementation::PowerManager>()->SystemIdleStatus();
         }
 
-        static winrt::Microsoft::ProjectReunion::PowerSchemePersonalityV1 PowerSchemePersonalityV1()
+        static winrt::Microsoft::ProjectReunion::EffectivePowerMode EffectivePowerMode()
         {
-            return make_self<factory_implementation::PowerManager>()->PowerSchemePersonalityV1();
-        }
-
-        static winrt::Microsoft::ProjectReunion::PowerSchemePersonalityV2 PowerSchemePersonalityV2()
-        {
-            return make_self<factory_implementation::PowerManager>()->PowerSchemePersonalityV2();
+            return make_self<factory_implementation::PowerManager>()->EffectivePowerMode();
         }
 
         static winrt::Microsoft::ProjectReunion::UserPresenceStatus UserPresenceStatus()
@@ -744,14 +703,9 @@ namespace winrt::Microsoft::ProjectReunion::implementation
             return make_self<factory_implementation::PowerManager>()->SystemIdleStatusChanged_Callback();
         }
 
-        static void PowerSchemePersonalityV1Changed_Callback(EFFECTIVE_POWER_MODE mode)
+        static void EffectivePowerModeChanged_Callback(EFFECTIVE_POWER_MODE mode)
         {
-            return make_self<factory_implementation::PowerManager>()->PowerSchemePersonalityV1Changed_Callback(mode);
-        }
-
-        static void PowerSchemePersonalityV2Changed_Callback(EFFECTIVE_POWER_MODE mode)
-        {
-            return make_self<factory_implementation::PowerManager>()->PowerSchemePersonalityV2Changed_Callback(mode);
+            return make_self<factory_implementation::PowerManager>()->EffectivePowerModeChanged_Callback(mode);
         }
 
         static void UserPresenceStatusChanged_Callback(DWORD userPresenceStatus)

--- a/dev/PowerNotifications/PowerNotifications.h
+++ b/dev/PowerNotifications/PowerNotifications.h
@@ -57,10 +57,15 @@ namespace winrt::Microsoft::ProjectReunion::implementation
     void SystemIdleStatus_Register();
     void SystemIdleStatus_Unregister();
 
-    EventType& PowerSchemePersonality_Event();
-    void PowerSchemePersonality_Register();
-    void PowerSchemePersonality_Unregister();
-    void PowerSchemePersonality_Update();
+    EventType& PowerSchemePersonalityV1_Event();
+    void PowerSchemePersonalityV1_Register();
+    void PowerSchemePersonalityV1_Unregister();
+    void PowerSchemePersonalityV1_Update();
+
+    EventType& PowerSchemePersonalityV2_Event();
+    void PowerSchemePersonalityV2_Register();
+    void PowerSchemePersonalityV2_Unregister();
+    void PowerSchemePersonalityV2_Update();
 
     EventType& UserPresenceStatus_Event();
     void UserPresenceStatus_Register();
@@ -101,7 +106,8 @@ namespace winrt::Microsoft::ProjectReunion::factory_implementation
         DWORD m_cachedUserPresenceStatus;
         DWORD m_cachedSystemAwayModeStatus;
         DWORD m_cachedPowerSourceStatus;
-        GUID  m_cachedPowerSchemePersonality;
+        EFFECTIVE_POWER_MODE m_cachedPowerSchemePersonalityV1;
+        EFFECTIVE_POWER_MODE m_cachedPowerSchemePersonalityV2;
         ULONGLONG m_cachedDischargeTime;
         winrt::Microsoft::ProjectReunion::SystemSuspendStatus m_systemSuspendStatus;
         ::EnergySaverStatus m_cachedEnergySaverStatus;
@@ -119,7 +125,8 @@ namespace winrt::Microsoft::ProjectReunion::factory_implementation
         EventType m_powerSourceStatusChangedEvent;
         EventType m_displayStatusChangedEvent;
         EventType m_systemIdleStatusChangedEvent;
-        EventType m_powerSchemePersonalityChangedEvent;
+        EventType m_powerSchemePersonalityV1ChangedEvent;
+        EventType m_powerSchemePersonalityv2ChangedEvent;
         EventType m_userPresenceStatusChangedEvent;
         EventType m_systemAwayModeStatusChangedEvent;
         EventType m_systemSuspendStatusChangedEvent;
@@ -130,7 +137,8 @@ namespace winrt::Microsoft::ProjectReunion::factory_implementation
         DischargeTimeRegistration m_dischargeTimeHandle;
         DisplayStatusRegistration m_displayStatusHandle;
         SystemIdleStatusRegistration m_systemIdleStatusHandle;
-        PowerSchemePersonalityRegistration m_powerSchemePersonalityHandle;
+        PowerSchemePersonalityRegistration m_powerSchemePersonalityV1Handle;
+        PowerSchemePersonalityRegistration m_powerSchemePersonalityV2Handle;
         UserPresenceStatusRegistration m_userPresenceStatusHandle;
         HPOWERNOTIFY m_systemSuspendHandle;
 
@@ -182,11 +190,17 @@ namespace winrt::Microsoft::ProjectReunion::factory_implementation
             &winrt::Microsoft::ProjectReunion::implementation::SystemIdleStatus_Unregister,
             &winrt::Microsoft::ProjectReunion::implementation::NoOperation };
 
-        PowerFunctionDetails powerSchemePersonalityFunc{
-            &winrt::Microsoft::ProjectReunion::implementation::PowerSchemePersonality_Event,
-            &winrt::Microsoft::ProjectReunion::implementation::PowerSchemePersonality_Register,
-            &winrt::Microsoft::ProjectReunion::implementation::PowerSchemePersonality_Unregister,
-            &winrt::Microsoft::ProjectReunion::implementation::PowerSchemePersonality_Update };
+        PowerFunctionDetails powerSchemePersonalityV1Func{
+            &winrt::Microsoft::ProjectReunion::implementation::PowerSchemePersonalityV1_Event,
+            &winrt::Microsoft::ProjectReunion::implementation::PowerSchemePersonalityV1_Register,
+            &winrt::Microsoft::ProjectReunion::implementation::PowerSchemePersonalityV1_Unregister,
+            &winrt::Microsoft::ProjectReunion::implementation::PowerSchemePersonalityV1_Update };
+
+        PowerFunctionDetails powerSchemePersonalityV2Func{
+            &winrt::Microsoft::ProjectReunion::implementation::PowerSchemePersonalityV2_Event,
+            &winrt::Microsoft::ProjectReunion::implementation::PowerSchemePersonalityV2_Register,
+            &winrt::Microsoft::ProjectReunion::implementation::PowerSchemePersonalityV2_Unregister,
+            &winrt::Microsoft::ProjectReunion::implementation::PowerSchemePersonalityV2_Update };
 
         PowerFunctionDetails userPresenceStatusFunc{
             &winrt::Microsoft::ProjectReunion::implementation::UserPresenceStatus_Event,
@@ -515,39 +529,50 @@ namespace winrt::Microsoft::ProjectReunion::factory_implementation
         }
 
 
-        // PowerSchemePersonality Functions
-        winrt::Microsoft::ProjectReunion::PowerSchemePersonality PowerSchemePersonality()
+        // PowerSchemePersonality v1 Functions
+        winrt::Microsoft::ProjectReunion::PowerSchemePersonalityV1 PowerSchemePersonalityV1()
         {
-            CheckRegistrationAndOrUpdateValue(powerSchemePersonalityFunc);
-            if (m_cachedPowerSchemePersonality == GUID_MAX_POWER_SAVINGS)
-            {
-                return PowerSchemePersonality::PowerSaver;
-            }
-            else if (m_cachedPowerSchemePersonality == GUID_MIN_POWER_SAVINGS)
-            {
-                return PowerSchemePersonality::HighPerformance;
-            }
-            else
-            {
-                return PowerSchemePersonality::Balanced;
-            }
-
+            CheckRegistrationAndOrUpdateValue(powerSchemePersonalityV1Func);
+            return static_cast<winrt::Microsoft::ProjectReunion::PowerSchemePersonalityV1>(m_cachedPowerSchemePersonalityV1);
         }
 
-        event_token PowerSchemePersonalityChanged(const PowerEventHandle& handler)
+        event_token PowerSchemePersonalityV1Changed(const PowerEventHandle& handler)
         {
-            return AddCallback(powerSchemePersonalityFunc, handler);
+            return AddCallback(powerSchemePersonalityV1Func, handler);
         }
 
-        void PowerSchemePersonalityChanged(const event_token& token)
+        void PowerSchemePersonalityV1Changed(const event_token& token)
         {
-            RemoveCallback(powerSchemePersonalityFunc, token);
+            RemoveCallback(powerSchemePersonalityV1Func, token);
         }
 
-        void PowerSchemePersonalityChanged_Callback(GUID powerSchemePersonality)
+        void PowerSchemePersonalityV1Changed_Callback(EFFECTIVE_POWER_MODE mode)
         {
-            m_cachedPowerSchemePersonality = powerSchemePersonality;
-            RaiseEvent(powerSchemePersonalityFunc);
+            m_cachedPowerSchemePersonalityV1 = mode;
+            RaiseEvent(powerSchemePersonalityV1Func);
+        }
+
+        // PowerSchemePersonality v2 Functions
+        winrt::Microsoft::ProjectReunion::PowerSchemePersonalityV2 PowerSchemePersonalityV2()
+        {
+            CheckRegistrationAndOrUpdateValue(powerSchemePersonalityV2Func);
+            return static_cast<winrt::Microsoft::ProjectReunion::PowerSchemePersonalityV2>(m_cachedPowerSchemePersonalityV2);
+        }
+
+        event_token PowerSchemePersonalityV2Changed(const PowerEventHandle& handler)
+        {
+            return AddCallback(powerSchemePersonalityV2Func, handler);
+        }
+
+        void PowerSchemePersonalityV2Changed(const event_token& token)
+        {
+            RemoveCallback(powerSchemePersonalityV2Func, token);
+        }
+
+        void PowerSchemePersonalityV2Changed_Callback(EFFECTIVE_POWER_MODE mode)
+        {
+            m_cachedPowerSchemePersonalityV2 = mode;
+            RaiseEvent(powerSchemePersonalityV2Func);
         }
 
 
@@ -668,9 +693,14 @@ namespace winrt::Microsoft::ProjectReunion::implementation
             return make_self<factory_implementation::PowerManager>()->SystemIdleStatus();
         }
 
-        static winrt::Microsoft::ProjectReunion::PowerSchemePersonality PowerSchemePersonality()
+        static winrt::Microsoft::ProjectReunion::PowerSchemePersonalityV1 PowerSchemePersonalityV1()
         {
-            return make_self<factory_implementation::PowerManager>()->PowerSchemePersonality();
+            return make_self<factory_implementation::PowerManager>()->PowerSchemePersonalityV1();
+        }
+
+        static winrt::Microsoft::ProjectReunion::PowerSchemePersonalityV2 PowerSchemePersonalityV2()
+        {
+            return make_self<factory_implementation::PowerManager>()->PowerSchemePersonalityV2();
         }
 
         static winrt::Microsoft::ProjectReunion::UserPresenceStatus UserPresenceStatus()
@@ -714,9 +744,14 @@ namespace winrt::Microsoft::ProjectReunion::implementation
             return make_self<factory_implementation::PowerManager>()->SystemIdleStatusChanged_Callback();
         }
 
-        static void PowerSchemePersonalityChanged_Callback(GUID powerSchemePersonality)
+        static void PowerSchemePersonalityV1Changed_Callback(EFFECTIVE_POWER_MODE mode)
         {
-            return make_self<factory_implementation::PowerManager>()->PowerSchemePersonalityChanged_Callback(powerSchemePersonality);
+            return make_self<factory_implementation::PowerManager>()->PowerSchemePersonalityV1Changed_Callback(mode);
+        }
+
+        static void PowerSchemePersonalityV2Changed_Callback(EFFECTIVE_POWER_MODE mode)
+        {
+            return make_self<factory_implementation::PowerManager>()->PowerSchemePersonalityV2Changed_Callback(mode);
         }
 
         static void UserPresenceStatusChanged_Callback(DWORD userPresenceStatus)

--- a/dev/PowerNotifications/PowerNotifications.h
+++ b/dev/PowerNotifications/PowerNotifications.h
@@ -611,7 +611,7 @@ namespace winrt::Microsoft::ProjectReunion::factory_implementation
 namespace winrt::Microsoft::ProjectReunion::implementation
 {
     // EffectivePowerMode variables
-    static ULONG g_powerModeVersion = NULL;
+    static std::atomic<ULONG> g_powerModeVersion = NULL;
     static PVOID g_powerModeHandle;
 
     struct PowerManager

--- a/dev/PowerNotifications/PowerNotifications.h
+++ b/dev/PowerNotifications/PowerNotifications.h
@@ -131,7 +131,6 @@ namespace winrt::Microsoft::ProjectReunion::factory_implementation
         DischargeTimeRegistration m_dischargeTimeHandle;
         DisplayStatusRegistration m_displayStatusHandle;
         SystemIdleStatusRegistration m_systemIdleStatusHandle;
-        PVOID m_powerModeHandle;
         UserPresenceStatusRegistration m_userPresenceStatusHandle;
         HPOWERNOTIFY m_systemSuspendHandle;
 

--- a/dev/PowerNotifications/PowerNotifications.h
+++ b/dev/PowerNotifications/PowerNotifications.h
@@ -61,12 +61,12 @@ namespace winrt::Microsoft::ProjectReunion::implementation
     void PowerSchemePersonality_Register();
     void PowerSchemePersonality_Unregister();
     void PowerSchemePersonality_Update();
-	
+
     EventType& UserPresenceStatus_Event();
     void UserPresenceStatus_Register();
     void UserPresenceStatus_Unregister();
     void UserPresenceStatus_Update();
-	
+
     EventType& SystemAwayModeStatus_Event();
     void SystemAwayModeStatus_Register();
     void SystemAwayModeStatus_Unregister();
@@ -107,9 +107,9 @@ namespace winrt::Microsoft::ProjectReunion::factory_implementation
         ::EnergySaverStatus m_cachedEnergySaverStatus;
         CompositeBatteryStatus m_cachedCompositeBatteryStatus;
         winrt::Microsoft::ProjectReunion::BatteryStatus m_batteryStatus;
-        winrt::Microsoft::ProjectReunion::BatteryStatus m_oldBatteryStatus { winrt::Microsoft::ProjectReunion::BatteryStatus::NotPresent };
+        winrt::Microsoft::ProjectReunion::BatteryStatus m_oldBatteryStatus{ winrt::Microsoft::ProjectReunion::BatteryStatus::NotPresent };
         winrt::Microsoft::ProjectReunion::PowerSupplyStatus m_powerSupplyStatus;
-        winrt::Microsoft::ProjectReunion::PowerSupplyStatus m_oldPowerSupplyStatus { winrt::Microsoft::ProjectReunion::PowerSupplyStatus::NotPresent };
+        winrt::Microsoft::ProjectReunion::PowerSupplyStatus m_oldPowerSupplyStatus{ winrt::Microsoft::ProjectReunion::PowerSupplyStatus::NotPresent };
 
         EventType m_EnergySaverStatusChangedEvent;
         EventType m_batteryStatusChangedEvent;
@@ -132,7 +132,6 @@ namespace winrt::Microsoft::ProjectReunion::factory_implementation
         SystemIdleStatusRegistration m_systemIdleStatusHandle;
         PowerSchemePersonalityRegistration m_powerSchemePersonalityHandle;
         UserPresenceStatusRegistration m_userPresenceStatusHandle;
-        SystemAwayModeStatusRegistration m_systemAwayModeStatusHandle;
         HPOWERNOTIFY m_systemSuspendHandle;
 
         PowerFunctionDetails energySaverStatusFunc{
@@ -194,12 +193,6 @@ namespace winrt::Microsoft::ProjectReunion::factory_implementation
             &winrt::Microsoft::ProjectReunion::implementation::UserPresenceStatus_Register,
             &winrt::Microsoft::ProjectReunion::implementation::UserPresenceStatus_Unregister,
             &winrt::Microsoft::ProjectReunion::implementation::UserPresenceStatus_Update };
-
-        PowerFunctionDetails systemAwayModeStatusFunc{
-            &winrt::Microsoft::ProjectReunion::implementation::SystemAwayModeStatus_Event,
-            &winrt::Microsoft::ProjectReunion::implementation::SystemAwayModeStatus_Register,
-            &winrt::Microsoft::ProjectReunion::implementation::SystemAwayModeStatus_Unregister,
-            &winrt::Microsoft::ProjectReunion::implementation::SystemAwayModeStatus_Update };
 
         PowerFunctionDetails systemSuspendFunc{
             &winrt::Microsoft::ProjectReunion::implementation::SystemSuspendStatus_Event,
@@ -273,7 +266,7 @@ namespace winrt::Microsoft::ProjectReunion::factory_implementation
             RaiseEvent(energySaverStatusFunc);
         }
 
-        // BatteryStatus Functions        
+        // BatteryStatus Functions
         void ProcessCompositeBatteryStatus(const CompositeBatteryStatus& compositeBatteryStatus)
         {
             // Calculate the remaining charge capacity based on the maximum charge
@@ -424,7 +417,7 @@ namespace winrt::Microsoft::ProjectReunion::factory_implementation
         }
 
 
-        // RemainingDischargeTime Functions        
+        // RemainingDischargeTime Functions
         Windows::Foundation::TimeSpan RemainingDischargeTime()
         {
             CheckRegistrationAndOrUpdateValue(remainingDischargeTimeFunc);
@@ -502,7 +495,7 @@ namespace winrt::Microsoft::ProjectReunion::factory_implementation
             // PReview: Should this be the default value?
             // We expect a persistently-queryable value, but
             // low-level APIs provide an idle->non-idle pulse event
- 
+
             return SystemIdleStatus::Busy;
         }
 
@@ -581,30 +574,6 @@ namespace winrt::Microsoft::ProjectReunion::factory_implementation
             RaiseEvent(userPresenceStatusFunc);
         }
 
-
-        // SystemAwayModeStatus Functions
-        winrt::Microsoft::ProjectReunion::SystemAwayModeStatus SystemAwayModeStatus()
-        {
-            CheckRegistrationAndOrUpdateValue(systemAwayModeStatusFunc);
-            return static_cast<winrt::Microsoft::ProjectReunion::SystemAwayModeStatus>(m_cachedSystemAwayModeStatus);
-        }
-
-        event_token SystemAwayModeStatusChanged(const PowerEventHandle& handler)
-        {
-            return AddCallback(systemAwayModeStatusFunc, handler);
-        }
-
-        void SystemAwayModeStatusChanged(const event_token& token)
-        {
-            RemoveCallback(systemAwayModeStatusFunc, token);
-        }
-
-        void SystemAwayModeStatusChanged_Callback(DWORD systemAwayModeStatus)
-        {
-            m_cachedSystemAwayModeStatus = systemAwayModeStatus;
-            RaiseEvent(systemAwayModeStatusFunc);
-        }
-
         //SystemSuspend Functions
         winrt::Microsoft::ProjectReunion::SystemSuspendStatus SystemSuspendStatus()
         {
@@ -649,7 +618,6 @@ namespace winrt::Microsoft::ProjectReunion::factory_implementation
         }
 
     };
-
 };
 
 namespace winrt::Microsoft::ProjectReunion::implementation
@@ -710,11 +678,6 @@ namespace winrt::Microsoft::ProjectReunion::implementation
             return make_self<factory_implementation::PowerManager>()->UserPresenceStatus();
         }
 
-        static winrt::Microsoft::ProjectReunion::SystemAwayModeStatus SystemAwayModeStatus()
-        {
-            return make_self<factory_implementation::PowerManager>()->SystemAwayModeStatus();
-        }
-
         static winrt::Microsoft::ProjectReunion::SystemSuspendStatus SystemSuspendStatus()
         {
             return make_self<factory_implementation::PowerManager>()->SystemSuspendStatus();
@@ -726,7 +689,7 @@ namespace winrt::Microsoft::ProjectReunion::implementation
             return make_self<factory_implementation::PowerManager>()->EnergySaverStatusChanged_Callback(energySaverStatus);
         }
 
-        static void CompositeBatteryStatusChanged_Callback(const CompositeBatteryStatus& compositeBatteryStatus)
+        static void CompositeBatteryStatusChanged_Callback(CompositeBatteryStatus compositeBatteryStatus)
         {
             return make_self<factory_implementation::PowerManager>()->CompositeBatteryStatusChanged_Callback(compositeBatteryStatus);
         }
@@ -761,9 +724,5 @@ namespace winrt::Microsoft::ProjectReunion::implementation
             return make_self<factory_implementation::PowerManager>()->UserPresenceStatusChanged_Callback(userPresenceStatus);
         }
 
-        static void SystemAwayModeStatusChanged_Callback(DWORD systemAwayModeStatus)
-        {
-            return make_self<factory_implementation::PowerManager>()->SystemAwayModeStatusChanged_Callback(systemAwayModeStatus);
-        }
     };
 }

--- a/dev/PowerNotifications/PowerNotifications.h
+++ b/dev/PowerNotifications/PowerNotifications.h
@@ -515,10 +515,12 @@ namespace winrt::Microsoft::ProjectReunion::factory_implementation
         }
 
         // EffectivePowerMode Functions
-        winrt::Microsoft::ProjectReunion::EffectivePowerMode EffectivePowerMode()
+        Windows::Foundation::IAsyncOperation<winrt::Microsoft::ProjectReunion::EffectivePowerMode> EffectivePowerMode()
         {
+            co_await resume_background();
             CheckRegistrationAndOrUpdateValue(EffectivePowerModeFunc);
-            return static_cast<winrt::Microsoft::ProjectReunion::EffectivePowerMode>(m_cachedPowerMode);
+            auto res = static_cast<winrt::Microsoft::ProjectReunion::EffectivePowerMode>(m_cachedPowerMode);
+            co_return res;
         }
 
         event_token EffectivePowerModeChanged(const PowerEventHandle& handler)
@@ -657,7 +659,7 @@ namespace winrt::Microsoft::ProjectReunion::implementation
             return make_self<factory_implementation::PowerManager>()->SystemIdleStatus();
         }
 
-        static winrt::Microsoft::ProjectReunion::EffectivePowerMode EffectivePowerMode()
+        static Windows::Foundation::IAsyncOperation<winrt::Microsoft::ProjectReunion::EffectivePowerMode> EffectivePowerMode()
         {
             return make_self<factory_implementation::PowerManager>()->EffectivePowerMode();
         }

--- a/dev/PowerNotifications/PowerNotifications.h
+++ b/dev/PowerNotifications/PowerNotifications.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <mutex>
+#include <powersetting.h>
 #include <PowerManager.g.h>
 #include <PowerNotificationsPal.h>
 #include <wil/resource.h>

--- a/dev/PowerNotifications/PowerNotifications.idl
+++ b/dev/PowerNotifications/PowerNotifications.idl
@@ -49,11 +49,24 @@ namespace Microsoft.ProjectReunion
         Busy
     };
 
-    enum PowerSchemePersonality
+    enum PowerSchemePersonalityV1
     {
-        HighPerformance = 0,
-        PowerSaver,
-        Balanced
+        BatterySaver,
+        BetterBattery,
+        Balanced,
+        HighPerformance,
+        MaxPerformance, // v1 last supported
+    };
+
+    enum PowerSchemePersonalityV2
+    {
+        BatterySaver,
+        BetterBattery,
+        Balanced,
+        HighPerformance,
+        MaxPerformance, // v1 last supported
+        GameMode,
+        MixedReality
     };
 
     enum UserPresenceStatus
@@ -103,8 +116,11 @@ namespace Microsoft.ProjectReunion
         static SystemIdleStatus SystemIdleStatus{ get; };
         static event Windows.Foundation.EventHandler<Object> SystemIdleStatusChanged;
 
-        static PowerSchemePersonality PowerSchemePersonality{ get; };
-        static event Windows.Foundation.EventHandler<Object> PowerSchemePersonalityChanged;
+        static PowerSchemePersonalityV1 PowerSchemePersonalityV1{ get; };
+        static event Windows.Foundation.EventHandler<Object> PowerSchemePersonalityV1Changed;
+
+        static PowerSchemePersonalityV2 PowerSchemePersonalityV2{ get; };
+        static event Windows.Foundation.EventHandler<Object> PowerSchemePersonalityV2Changed;
 
         static UserPresenceStatus UserPresenceStatus{ get; };
         static event Windows.Foundation.EventHandler<Object> UserPresenceStatusChanged;

--- a/dev/PowerNotifications/PowerNotifications.idl
+++ b/dev/PowerNotifications/PowerNotifications.idl
@@ -107,7 +107,7 @@ namespace Microsoft.ProjectReunion
         static SystemIdleStatus SystemIdleStatus{ get; };
         static event Windows.Foundation.EventHandler<Object> SystemIdleStatusChanged;
 
-        static EffectivePowerMode EffectivePowerMode{ get; };
+        static Windows.Foundation.IAsyncOperation<EffectivePowerMode> EffectivePowerMode{ get; };
         static event Windows.Foundation.EventHandler<Object> EffectivePowerModeChanged;
 
         static UserPresenceStatus UserPresenceStatus{ get; };

--- a/dev/PowerNotifications/PowerNotifications.idl
+++ b/dev/PowerNotifications/PowerNotifications.idl
@@ -20,7 +20,7 @@ namespace Microsoft.ProjectReunion
         Idle,
         Charging
     };
-    
+
     enum PowerSupplyStatus
     {
         NotPresent = 0,
@@ -35,14 +35,14 @@ namespace Microsoft.ProjectReunion
         DC,
         ShortTerm
     };
-    
+
     enum DisplayStatus
     {
         Off = 0,
         On,
         Dimmed
     };
-    
+
     enum SystemIdleStatus
     {
         Idle = 0,
@@ -60,12 +60,6 @@ namespace Microsoft.ProjectReunion
     {
         Present = 0,
         Absent
-    };
-
-    enum SystemAwayModeStatus
-    {
-        Entering = 0,
-        Exiting
     };
 
     enum SystemSuspendStatus
@@ -99,7 +93,7 @@ namespace Microsoft.ProjectReunion
         // Properties and events based on PowerSettingRegisterNotification's state
         static PowerSourceStatus PowerSourceStatus{ get; };
         static event Windows.Foundation.EventHandler<Object> PowerSourceStatusChanged;
-        
+
         static DisplayStatus DisplayStatus{ get; };
         static event Windows.Foundation.EventHandler<Object> DisplayStatusChanged;
 
@@ -108,15 +102,12 @@ namespace Microsoft.ProjectReunion
         // system is idle or wishes to become so).
         static SystemIdleStatus SystemIdleStatus{ get; };
         static event Windows.Foundation.EventHandler<Object> SystemIdleStatusChanged;
-        
+
         static PowerSchemePersonality PowerSchemePersonality{ get; };
         static event Windows.Foundation.EventHandler<Object> PowerSchemePersonalityChanged;
-        
+
         static UserPresenceStatus UserPresenceStatus{ get; };
         static event Windows.Foundation.EventHandler<Object> UserPresenceStatusChanged;
-        
-        static SystemAwayModeStatus SystemAwayModeStatus{ get; };
-        static event Windows.Foundation.EventHandler<Object> SystemAwayModeStatusChanged;
 
         static SystemSuspendStatus SystemSuspendStatus{ get; };
         static event Windows.Foundation.EventHandler<Object> SystemSuspendStatusChanged;

--- a/dev/PowerNotifications/PowerNotifications.idl
+++ b/dev/PowerNotifications/PowerNotifications.idl
@@ -49,16 +49,7 @@ namespace Microsoft.ProjectReunion
         Busy
     };
 
-    enum PowerSchemePersonalityV1
-    {
-        BatterySaver,
-        BetterBattery,
-        Balanced,
-        HighPerformance,
-        MaxPerformance, // v1 last supported
-    };
-
-    enum PowerSchemePersonalityV2
+    enum EffectivePowerMode
     {
         BatterySaver,
         BetterBattery,
@@ -116,11 +107,8 @@ namespace Microsoft.ProjectReunion
         static SystemIdleStatus SystemIdleStatus{ get; };
         static event Windows.Foundation.EventHandler<Object> SystemIdleStatusChanged;
 
-        static PowerSchemePersonalityV1 PowerSchemePersonalityV1{ get; };
-        static event Windows.Foundation.EventHandler<Object> PowerSchemePersonalityV1Changed;
-
-        static PowerSchemePersonalityV2 PowerSchemePersonalityV2{ get; };
-        static event Windows.Foundation.EventHandler<Object> PowerSchemePersonalityV2Changed;
+        static EffectivePowerMode EffectivePowerMode{ get; };
+        static event Windows.Foundation.EventHandler<Object> EffectivePowerModeChanged;
 
         static UserPresenceStatus UserPresenceStatus{ get; };
         static event Windows.Foundation.EventHandler<Object> UserPresenceStatusChanged;

--- a/dev/PowerNotifications/PowerNotificationsPal.h
+++ b/dev/PowerNotifications/PowerNotificationsPal.h
@@ -14,7 +14,7 @@ struct CompositeBatteryStatus
 
 DECLARE_HANDLE(CompositeBatteryStatusRegistration);
 HRESULT GetCompositeBatteryStatus(CompositeBatteryStatus* compositeBatteryStatusOut);
-typedef void (*OnCompositeBatteryStatusChanged)(const CompositeBatteryStatus& compositeBatteryStatus);
+typedef void (*OnCompositeBatteryStatusChanged)(CompositeBatteryStatus compositeBatteryStatus);
 HRESULT RegisterCompositeBatteryStatusChangedListener(OnCompositeBatteryStatusChanged listener, CompositeBatteryStatusRegistration* registration);
 HRESULT UnregisterCompositeBatteryStatusChangedListener(CompositeBatteryStatusRegistration registration);
 

--- a/test/PowerNotificationsTests/PowerTests.cpp
+++ b/test/PowerNotificationsTests/PowerTests.cpp
@@ -172,23 +172,6 @@ namespace ProjectReunionPowerTests
             VERIFY_ARE_EQUAL(stat, UserPresenceStatus::Absent);
         }
 
-        TEST_METHOD(GetSystemAwayModeStatus)
-        {
-            auto stat = PowerManager::SystemAwayModeStatus();
-            VERIFY_ARE_EQUAL(stat, SystemAwayModeStatus::Entering);
-        }
-        TEST_METHOD(SystemAwayModeStatusCallback)
-        {
-            auto stat = SystemAwayModeStatus::Entering;
-            auto token = PowerManager::SystemAwayModeStatusChanged([&](const auto&, winrt::Windows::Foundation::IInspectable obj)
-            {
-                stat = PowerManager::SystemAwayModeStatus();
-            });
-            std::this_thread::sleep_for(std::chrono::milliseconds(100));
-            PowerManager::SystemAwayModeStatusChanged(token);
-            VERIFY_ARE_EQUAL(stat, SystemAwayModeStatus::Exiting);
-        }
-
         TEST_METHOD(SystemSuspendStatusCallback)
         {
             // Since the called API is for sleep/hibernate, we just test the registration

--- a/test/PowerNotificationsTests/PowerTests.cpp
+++ b/test/PowerNotificationsTests/PowerTests.cpp
@@ -138,23 +138,6 @@ namespace ProjectReunionPowerTests
             VERIFY_ARE_EQUAL(callback_success, true);
         }
 
-        TEST_METHOD(GetPowerSchemePersonality)
-        {
-            auto stat = PowerManager::PowerSchemePersonality();
-            VERIFY_ARE_EQUAL(stat, PowerSchemePersonality::HighPerformance);
-        }
-        TEST_METHOD(PowerSchemePersonalityCallback)
-        {
-            auto stat = PowerSchemePersonality::HighPerformance;
-            auto token = PowerManager::PowerSchemePersonalityChanged([&](const auto&, winrt::Windows::Foundation::IInspectable obj)
-            {
-                stat = PowerManager::PowerSchemePersonality();
-            });
-            std::this_thread::sleep_for(std::chrono::milliseconds(100));
-            PowerManager::PowerSchemePersonalityChanged(token);
-            VERIFY_ARE_EQUAL(stat, PowerSchemePersonality::PowerSaver);
-        }
-
         TEST_METHOD(GetUserPresenceStatus)
         {
             auto stat = PowerManager::UserPresenceStatus();


### PR DESCRIPTION
- Amending PowerMode Functions to use 
[PowerRegisterForEffectivePowerModeNotifications()](https://docs.microsoft.com/en-us/windows/win32/api/powersetting/nf-powersetting-powerregisterforeffectivepowermodenotifications)
- Removed SystemAwayStatus code